### PR TITLE
fix(startup): 解决 cargo run 无法启动的问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# 数据库连接配置
+DATABASE_URL=postgres://username:password@localhost:5432/database_name
+
+# JWT 密钥（生产环境请使用安全的随机字符串）
+SECRET_KEY=your-super-secret-key
+
+# 服务监听地址（可选，默认 0.0.0.0:3000）
+LISTEN_ADDRESS=0.0.0.0:3000

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_name ON users(name);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);


### PR DESCRIPTION
新增文件：
- .env.example - 环境变量示例文件
- init.sql - 数据库初始化脚本

解决的问题：
- 缺少数据库表结构
- 提供环境变量配置参考

使用方法：
1. 确保 PostgreSQL 已安装并运行
2. 创建数据库：createdb wildcard
3. 执行初始化脚本：psql -d wildcard -f init.sql
4. 创建 .env 文件（参考 .env.example）
5. 启动服务：cargo run