### PR TITLE
fix(user): register error i18n and verification code retention

### DIFF
--- a/src/infrastructure/user.rs
+++ b/src/infrastructure/user.rs
@@ -24,10 +24,10 @@ impl UserRepository {
             .map_err(|e| {
                 if let sqlx::error::Error::Database(db_err) = &e {
                     match db_err.constraint() {
-                        Some("users_name_key") => {
+                        Some("users_name_key" | "idx_users_name") => {
                             return AppError::UserAlreadyExist("用户名已存在".to_string());
                         }
-                        Some("users_email_key") => {
+                        Some("users_email_key" | "idx_users_email") => {
                             return AppError::UserAlreadyExist("该邮箱已注册".to_string());
                         }
                         Some(other) => {
@@ -106,7 +106,7 @@ impl UserRepository {
         .map_err(|e| {
             if let sqlx::error::Error::Database(db_err) = &e {
                 match db_err.constraint() {
-                    Some("users_name_key") => {
+                    Some("users_name_key" | "idx_users_name") => {
                         return AppError::UserAlreadyExist("用户名已存在".to_string());
                     }
                     Some(other) => {

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -310,14 +310,15 @@ pub async fn register(
     }
 
     {
-        let mut guard = codes.write().await;
+        let guard = codes.read().await;
         let stored = guard
             .get(&email)
             .cloned()
             .ok_or_else(|| AppError::InvalidInput("请先发送验证码".to_string()))?;
+        drop(guard);
 
         if time::OffsetDateTime::now_utc().unix_timestamp() > stored.expires_at_unix {
-            guard.remove(&email);
+            codes.write().await.remove(&email);
             return Err(AppError::InvalidInput(
                 "验证码已过期，请重新发送".to_string(),
             ));
@@ -326,8 +327,6 @@ pub async fn register(
         if stored.code != verification_code {
             return Err(AppError::InvalidInput("验证码错误".to_string()));
         }
-
-        guard.remove(&email);
     }
 
     let user = User {
@@ -337,6 +336,9 @@ pub async fn register(
         password,
     };
     user_repo.register(user).await?;
+
+    // 仅在注册插入成功后才消费验证码，避免唯一约束等错误导致用户无法重试。
+    codes.write().await.remove(&email);
 
     let created = user_repo
         .find_by_email(&email)


### PR DESCRIPTION
飞书任务板 \`recvkg8kG6uoKb\`。

## Bug A
\`POST /api/user/register\` 在用户名冲突时返回原始英文 sqlx 错误：
\`\`\`
error returned from database: duplicate key value violates unique constraint "idx_users_name"
\`\`\`

**根因**：生产 DB 上 \`name\` / \`email\` 列存在两套唯一索引（\`users_name_key\` + \`idx_users_name\`），sqlx 上报后者，但代码只 match 了前者，走 fallback 把原始英文 \`e.to_string()\` 返给前端。

**修复**：\`src/infrastructure/user.rs\` 在 \`register\` 与 \`update_username\` 的 constraint match 中新增 \`idx_users_name\` / \`idx_users_email\` 分支（or-pattern）。

## Bug B
触发 Bug A 后，用户改一个新用户名直接重试 -> 提示"请先发送验证码"。

**根因**：\`src/interface/user.rs::register\` 在校验码通过后立刻 \`guard.remove(&email)\`，随后才执行 \`user_repo.register\`。DB 插入失败时验证码已被消费。

**修复**：校验阶段持 read 锁取出码值即 drop；过期分支升级写锁删除；正常路径推迟到 \`user_repo.register\` 成功后再 \`codes.write().await.remove(&email)\`。

## 验证
- \`cargo fmt --all\`、\`cargo build\`、\`cargo test --bins --lib --tests\`、\`cargo clippy --all-targets -- -D warnings\` 全过
- E2E 实测：
  - 用已存在用户名注册 -> \`{"success":false,"message":"用户名已存在"}\` ✅
  - 紧接着换新用户名复用同一验证码 -> 注册成功并返回 token ✅

## 测试覆盖说明
本次没新增单元测试。现有测试基础设施是 in-memory mock TestApp（\`src/lib.rs\`），不经过真实 Axum router，没法直接验证这两个 handler 路径。引入 \`axum-test\` 做真集成测试 scope 远超本次修复，留待单独 issue。

Closes #67