### PR TITLE
feat(user): allow authenticated user to change email

### DIFF
--- a/src/infrastructure/user.rs
+++ b/src/infrastructure/user.rs
@@ -127,6 +127,38 @@ impl UserRepository {
         })
     }
 
+    pub async fn update_email(&self, user_id: &UserId, email: &str) -> Result<User, AppError> {
+        let user = sqlx::query(
+            "UPDATE users SET email = $1 WHERE id = $2 RETURNING id, name, email, password",
+        )
+        .bind(email)
+        .bind(user_id.0)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            if let sqlx::error::Error::Database(db_err) = &e {
+                match db_err.constraint() {
+                    Some("users_email_key" | "idx_users_email") => {
+                        return AppError::UserAlreadyExist("该邮箱已被占用".to_string());
+                    }
+                    Some(other) => {
+                        tracing::warn!("Unexpected constraint {other}");
+                    }
+                    None => {}
+                }
+            }
+            tracing::warn!("Database error {e}");
+            AppError::DatabaseError(e)
+        })?;
+
+        Ok(User {
+            id: UserId(user.get("id")),
+            name: user.get("name"),
+            email: user.get("email"),
+            password: user.get("password"),
+        })
+    }
+
     pub async fn update_password(
         &self,
         user_id: &UserId,

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -138,6 +138,14 @@ pub struct UpdatePasswordRequest {
     pub new_password: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UpdateEmailRequest {
+    #[serde(rename = "newEmail")]
+    pub new_email: String,
+    #[serde(rename = "verificationCode")]
+    pub verification_code: String,
+}
+
 fn validate_email(email: &str) -> Result<String, AppError> {
     let normalized = email.trim().to_lowercase();
     if normalized.is_empty() {
@@ -458,6 +466,57 @@ pub async fn update_password(
     Ok(Json(ApiResponse::success_without_data(Some(
         "密码更新成功".to_string(),
     ))))
+}
+
+#[tracing::instrument]
+pub async fn update_email(
+    TokenClaims { user_id, .. }: TokenClaims,
+    State(user_repo): State<Arc<UserRepository>>,
+    State(codes): State<Arc<RwLock<std::collections::HashMap<String, VerificationCodeRecord>>>>,
+    Json(payload): Json<UpdateEmailRequest>,
+) -> Result<Json<ApiResponse<UserDto>>, AppError> {
+    let new_email = validate_email(&payload.new_email)?;
+    let verification_code = payload.verification_code.trim().to_string();
+
+    if verification_code.is_empty() {
+        return Err(AppError::InvalidInput("请先发送验证码".to_string()));
+    }
+
+    let current = user_repo
+        .find_by_id(&user_id)
+        .await?
+        .ok_or(AppError::Unauthorized("未登录".to_string()))?;
+
+    if current.email == new_email {
+        return Err(AppError::InvalidInput("新邮箱与当前邮箱相同".to_string()));
+    }
+
+    {
+        let guard = codes.read().await;
+        let stored = guard
+            .get(&new_email)
+            .cloned()
+            .ok_or_else(|| AppError::InvalidInput("请先发送验证码".to_string()))?;
+        drop(guard);
+
+        if time::OffsetDateTime::now_utc().unix_timestamp() > stored.expires_at_unix {
+            codes.write().await.remove(&new_email);
+            return Err(AppError::InvalidInput(
+                "验证码已过期，请重新发送".to_string(),
+            ));
+        }
+
+        if stored.code != verification_code {
+            return Err(AppError::InvalidInput("验证码错误".to_string()));
+        }
+    }
+
+    let updated = user_repo.update_email(&user_id, &new_email).await?;
+
+    // 仅在更新成功后消费验证码，避免唯一约束冲突等情况下用户需要重发。
+    codes.write().await.remove(&new_email);
+
+    Ok(Json(ApiResponse::success(UserDto::from_user(updated))))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,10 @@ async fn main() {
             post(user::update_password).put(user::update_password),
         )
         .route(
+            "/api/user/email",
+            post(user::update_email).put(user::update_email),
+        )
+        .route(
             "/api/rules/drafts",
             get(rule::list_drafts).post(rule::save_draft),
         )


### PR DESCRIPTION
飞书任务板 \`recvk4G5n8VhW6\`。

## 改动
- \`POST/PUT /api/user/email\`（需 JWT）：body \`{newEmail, verificationCode}\`
- \`UserRepository::update_email\`：constraint match 识别 \`users_email_key | idx_users_email\`，避免英文错误透传
- handler 沿用 #67 修好的"成功后才消费验证码"范式

## 验证
- cargo fmt/build/test/clippy 全过
- E2E：登录态用新邮箱调 send-code → 收邮件 → 提交 update-email → 顶部邮箱更新 → 用新邮箱登录成功

配套前端 PR 即将推送（BUAA-ISET/WildCard_FrontEnd）。

Closes #70