### PR TITLE
chore(user): replace timestamp-based verification code with rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,13 +779,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1120,7 +1132,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1388,7 +1400,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1710,6 +1722,12 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1721,8 +1739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1736,12 +1764,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2249,7 +2296,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2288,7 +2335,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2721,7 +2768,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -2965,6 +3012,7 @@ dependencies = [
  "lettre",
  "mockall",
  "password-hash",
+ "rand 0.9.4",
  "rand_core 0.10.1",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ dotenv = "0.15.0"
 jsonwebtoken ={version= "10.3.0", features=["rust_crypto"]}
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-native-tls", "builder"] }
 password-hash = {version="^0.5",features= ["std"] }
+rand = "0.9"
 rand_core = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -200,11 +200,9 @@ fn validate_password(password: &str, empty_message: &str) -> Result<String, AppE
 }
 
 fn generate_code() -> String {
-    let value = time::OffsetDateTime::now_utc()
-        .unix_timestamp_nanos()
-        .unsigned_abs()
-        % 900_000;
-    format!("{:06}", value + 100_000)
+    use rand::Rng;
+    let value: u32 = rand::rng().random_range(0..1_000_000);
+    format!("{value:06}")
 }
 
 fn build_token(user_id: UserId, jwt_secret: &[u8]) -> Result<String, AppError> {
@@ -757,5 +755,24 @@ mod tests {
         assert_eq!(extension_for_mime("image/gif"), None);
         assert_eq!(extension_for_mime("application/pdf"), None);
         assert_eq!(extension_for_mime(""), None);
+    }
+
+    #[test]
+    fn generate_code_returns_six_digits() {
+        for _ in 0..50 {
+            let code = super::generate_code();
+            assert_eq!(code.len(), 6);
+            assert!(code.chars().all(|c| c.is_ascii_digit()));
+        }
+    }
+
+    #[test]
+    fn generate_code_is_not_deterministic() {
+        let mut codes = std::collections::HashSet::new();
+        for _ in 0..50 {
+            codes.insert(super::generate_code());
+        }
+        // 50 个调用拿到 50 个全相同结果的概率是 (1/10^6)^49,实际上一定不会发生
+        assert!(codes.len() > 1, "generate_code 应该返回随机序列");
     }
 }


### PR DESCRIPTION
见 #76。`cargo fmt/build/test/clippy` 全过,新增 2 个单元测试覆盖格式与不可预测性。

Closes #76