### PR TITLE
fix(cors): document production origins in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ SECRET_KEY=your-super-secret-key
 # 服务监听地址（可选，默认 0.0.0.0:3000）
 LISTEN_ADDRESS=0.0.0.0:3000
 
+# 跨域白名单（逗号分隔；除 localhost:5173 与 :8084 之外的 origin 都必须在这里）
+# 生产 / 联调时常用配置：
+#   CORS_ALLOWED_ORIGINS=http://isetwildcard.me,https://isetwildcard.me,http://buaa-iset.github.io,https://buaa-iset.github.io
+CORS_ALLOWED_ORIGINS=
+
 # 验证码邮件 SMTP 配置（可选，五项全配置才启用真实邮件发送；
 # 否则 /api/user/send-code 仍然在响应里通过 debugCode 字段返回明文验证码以便本地开发）
 SMTP_HOST=smtp.qq.com


### PR DESCRIPTION
见 #78。代码不变,只在 `.env.example` 文档化生产 origin 推荐配置。部署机 `.env` 已同步并重启,curl OPTIONS 已返回正确 `access-control-allow-origin`。

Closes #78