### PR TITLE
test: cover websocket room session behavior

### DIFF
--- a/tests/websocket_session_behavior_tests.rs
+++ b/tests/websocket_session_behavior_tests.rs
@@ -1,0 +1,17 @@
+use wildcard_backend::websocket::RoomSession;
+
+#[test]
+fn websocket_room_session_keeps_participants_sorted_and_idempotent() {
+    let mut session = RoomSession::new("room-1");
+
+    session.join("user-b");
+    session.join("user-a");
+    session.join("user-b");
+
+    assert_eq!(session.participant_count(), 2);
+    assert_eq!(session.participants(), vec!["user-a", "user-b"]);
+
+    let event = session.leave("missing-user");
+    assert_eq!(event.action, "left");
+    assert_eq!(session.participant_count(), 2);
+}


### PR DESCRIPTION
## Summary
- Add websocket session tests for idempotent duplicate joins.
- Cover sorted participants and unknown-user leave behavior.
- Only test files are changed.

## Test Plan
- cargo test --test websocket_session_behavior_tests

Closes #93