### PR TITLE
ci: add backend coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  COVERAGE_IGNORE_FILENAME_REGEX: '(^|/)src/(main|state|lib)\.rs'
 
 jobs:
   rustfmt:
@@ -58,3 +60,37 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+          cache: true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: |
+          cargo llvm-cov --workspace --all-targets --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}" --lcov --output-path lcov.info
+          cargo llvm-cov report --summary-only --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}" | tee coverage-summary.txt
+          {
+            echo "### Backend coverage"
+            echo '```text'
+            cat coverage-summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload LCOV report
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-lcov
+          path: lcov.info
+          if-no-files-found: error

--- a/doc/测试覆盖率.md
+++ b/doc/测试覆盖率.md
@@ -1,0 +1,51 @@
+# 后端测试覆盖率
+
+本仓库在 CI 中通过 `cargo-llvm-cov` 生成后端覆盖率信息。前端仓库已经有 `npm run test:coverage` 与 Vitest coverage 配置，因此这里仅补后端覆盖率链路。
+
+## 统计口径
+
+Coverage job 统计真实后端实现代码：
+
+- `src/domain/**`：规则引擎、房间/用户/游戏等领域模型与规则逻辑。
+- `src/interface/**`：HTTP handler、认证提取、房间/规则/用户接口逻辑。
+- `src/infrastructure/**`：数据库仓储、邮件发送等外部依赖适配逻辑。
+- `src/error.rs`：统一错误到 HTTP 响应的映射逻辑。
+
+Coverage job 排除以下文件：
+
+- `src/main.rs`：启动入口，负责读取环境变量、连接数据库、装配路由并启动监听。它更适合通过冒烟测试或部署检查验证，不适合作为单元/接口覆盖率分母。
+- `src/state.rs`：Axum `FromRef` 状态注入 glue，主要是依赖转发代码，纳入分母会稀释功能覆盖率。
+- `src/lib.rs`：当前主要是测试辅助 façade 与样例 `TestApp`，不是线上服务入口；纳入分母会让覆盖率看起来比真实接口覆盖更高。
+
+## CI 输出
+
+`.github/workflows/ci.yaml` 中的 `Coverage` job 会执行：
+
+```bash
+cargo llvm-cov --workspace --all-targets --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}" --lcov --output-path lcov.info
+cargo llvm-cov report --summary-only --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}"
+```
+
+CI 结果包含两类信息：
+
+- GitHub Actions job summary 中的覆盖率摘要，便于直接查看行覆盖率、函数覆盖率等统计。
+- `backend-lcov` artifact，内含 `lcov.info`，便于后续接入 Codecov、Coveralls 或其他覆盖率看板。
+
+当前只上报覆盖率，不设置最低阈值，避免测试分支刚接入时因为历史覆盖率不足阻塞合并。后续如果团队确定目标，可以在 coverage job 中增加阈值校验。
+
+## 本地运行
+
+首次本地运行需要安装工具：
+
+```bash
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov
+```
+
+生成覆盖率：
+
+```bash
+export COVERAGE_IGNORE_FILENAME_REGEX="(^|/)src/(main|state|lib)\.rs"
+cargo llvm-cov --workspace --all-targets --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}" --lcov --output-path lcov.info
+cargo llvm-cov report --summary-only --ignore-filename-regex "${COVERAGE_IGNORE_FILENAME_REGEX}"
+```


### PR DESCRIPTION
## Summary

- add a backend CI Coverage job using `cargo-llvm-cov`
- scope coverage to real backend implementation files and exclude `src/main.rs`, `src/state.rs`, and `src/lib.rs`
- publish coverage summary to the GitHub Actions step summary
- upload `lcov.info` as the `backend-lcov` artifact
- document the backend coverage workflow and counting scope in `doc/测试覆盖率.md`

Closes #108

## Verification

- `cargo fmt --check`
- `cargo test --verbose`
- GitHub Actions CI on `test/backend-coverage-ci`