### PR TITLE
feat(market): rule reviews + ratings aggregation

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -42,3 +42,18 @@ CREATE TABLE IF NOT EXISTS rule_published (
 
 CREATE INDEX IF NOT EXISTS idx_rule_published_owner_updated
     ON rule_published(owner_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS rule_reviews (
+    id UUID PRIMARY KEY,
+    rule_id UUID NOT NULL,
+    author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    rating SMALLINT NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    content TEXT NOT NULL DEFAULT '',
+    image_url VARCHAR(512),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (rule_id, author_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rule_reviews_rule_created
+    ON rule_reviews(rule_id, created_at DESC);

--- a/src/interface/market.rs
+++ b/src/interface/market.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
@@ -5,10 +6,12 @@ use axum::{
     extract::{Path, Query, State},
 };
 use serde::{Deserialize, Serialize};
+use sqlx::Row;
 
 use crate::error::AppError;
 use crate::infrastructure::user::UserRepository;
-use crate::interface::rule::ApiResponse;
+use crate::interface::auth::TokenClaims;
+use crate::interface::rule::{ApiResponse, RulePersistence};
 use crate::state::{RoomStore, RuleStore};
 
 #[derive(Debug, Clone, Serialize)]
@@ -177,6 +180,7 @@ fn build_summary(
 pub async fn list_published_rules(
     State(store): State<RuleStore>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(persistence): State<RulePersistence>,
     Query(params): Query<RuleQueryParams>,
 ) -> Result<Json<ApiResponse<Vec<PublishedRuleSummary>>>, AppError> {
     let snapshot: Vec<(String, String, String, String, i64, u8)> = {
@@ -214,12 +218,21 @@ pub async fn list_published_rules(
     }
 
     summaries.sort_by_key(|s| std::cmp::Reverse(s.published_at));
+    let rule_ids: Vec<String> = summaries.iter().map(|s| s.id.clone()).collect();
+    let stats_map = fetch_rating_stats_map(&persistence, &rule_ids).await;
+    for summary in summaries.iter_mut() {
+        if let Some(stats) = stats_map.get(&summary.id) {
+            summary.rating = stats.average;
+            summary.review_count = stats.count;
+        }
+    }
     Ok(Json(ApiResponse::success(summaries)))
 }
 
 pub async fn get_published_rule_detail(
     State(store): State<RuleStore>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(persistence): State<RulePersistence>,
     Path(rule_id): Path<String>,
 ) -> Result<Json<ApiResponse<PublishedRuleDetail>>, AppError> {
     let snapshot = {
@@ -240,19 +253,37 @@ pub async fn get_published_rule_detail(
         developer,
     );
 
+    let mut summary = summary;
+    if let Ok(rule_uuid) = extract_rule_uuid(&summary.id) {
+        if let Ok(stats) = fetch_rating_stats(&persistence, rule_uuid).await {
+            summary.rating = stats.average;
+            summary.review_count = stats.count;
+        }
+        let reviews = fetch_reviews(&persistence, rule_uuid, 20)
+            .await
+            .unwrap_or_default();
+        let detail = PublishedRuleDetail {
+            summary,
+            introduction,
+            screenshots: Vec::new(),
+            reviews,
+        };
+        return Ok(Json(ApiResponse::success(detail)));
+    }
+
     let detail = PublishedRuleDetail {
         summary,
         introduction,
         screenshots: Vec::new(),
         reviews: Vec::new(),
     };
-
     Ok(Json(ApiResponse::success(detail)))
 }
 
 pub async fn list_developer_rules(
     State(store): State<RuleStore>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(persistence): State<RulePersistence>,
     Path(developer_id): Path<String>,
     Query(params): Query<RuleQueryParams>,
 ) -> Result<Json<ApiResponse<Vec<PublishedRuleSummary>>>, AppError> {
@@ -291,6 +322,14 @@ pub async fn list_developer_rules(
     }
 
     summaries.sort_by_key(|s| std::cmp::Reverse(s.published_at));
+    let rule_ids: Vec<String> = summaries.iter().map(|s| s.id.clone()).collect();
+    let stats_map = fetch_rating_stats_map(&persistence, &rule_ids).await;
+    for summary in summaries.iter_mut() {
+        if let Some(stats) = stats_map.get(&summary.id) {
+            summary.rating = stats.average;
+            summary.review_count = stats.count;
+        }
+    }
     Ok(Json(ApiResponse::success(summaries)))
 }
 
@@ -327,4 +366,213 @@ pub async fn list_rooms_for_rule(
 
     rooms.sort_by(|a, b| a.code.cmp(&b.code));
     Ok(Json(ApiResponse::success(rooms)))
+}
+
+// ---- Reviews ----
+
+#[derive(Debug, Deserialize)]
+pub struct CreateReviewRequest {
+    pub rating: u8,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default, rename = "imageUrl")]
+    pub image_url: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RuleRatingStats {
+    pub average: f32,
+    pub count: u32,
+}
+
+fn extract_rule_uuid(rule_id: &str) -> Result<uuid::Uuid, AppError> {
+    let trimmed = rule_id.strip_prefix("rule_").unwrap_or(rule_id);
+    uuid::Uuid::parse_str(trimmed).map_err(|e| AppError::InvalidInput(format!("规则 ID 无效：{e}")))
+}
+
+async fn fetch_rating_stats(
+    persistence: &RulePersistence,
+    rule_uuid: uuid::Uuid,
+) -> Result<RuleRatingStats, AppError> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            COALESCE(AVG(rating)::float4, 0.0) AS avg,
+            COUNT(*)::int4 AS cnt
+        FROM rule_reviews
+        WHERE rule_id = $1
+        "#,
+    )
+    .bind(rule_uuid)
+    .fetch_one(&persistence.pool)
+    .await
+    .map_err(AppError::DatabaseError)?;
+    Ok(RuleRatingStats {
+        average: row.get::<f32, _>("avg"),
+        count: row.get::<i32, _>("cnt") as u32,
+    })
+}
+
+async fn fetch_rating_stats_map(
+    persistence: &RulePersistence,
+    rule_ids: &[String],
+) -> HashMap<String, RuleRatingStats> {
+    let uuids: Vec<uuid::Uuid> = rule_ids
+        .iter()
+        .filter_map(|id| extract_rule_uuid(id).ok())
+        .collect();
+    let mut map = HashMap::new();
+    if uuids.is_empty() {
+        return map;
+    }
+    let rows = match sqlx::query(
+        r#"
+        SELECT
+            rule_id::text AS rule_id,
+            COALESCE(AVG(rating)::float4, 0.0) AS avg,
+            COUNT(*)::int4 AS cnt
+        FROM rule_reviews
+        WHERE rule_id = ANY($1)
+        GROUP BY rule_id
+        "#,
+    )
+    .bind(&uuids)
+    .fetch_all(&persistence.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!("fetch_rating_stats_map failed: {e}");
+            return map;
+        }
+    };
+    for row in rows {
+        let uuid_str: String = row.get("rule_id");
+        let stats = RuleRatingStats {
+            average: row.get::<f32, _>("avg"),
+            count: row.get::<i32, _>("cnt") as u32,
+        };
+        // 内存里 published rule.id 是带 "rule_" 前缀的形式
+        map.insert(format!("rule_{uuid_str}"), stats);
+    }
+    map
+}
+
+async fn fetch_reviews(
+    persistence: &RulePersistence,
+    rule_uuid: uuid::Uuid,
+    limit: i64,
+) -> Result<Vec<RuleReview>, AppError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            r.id::text AS id,
+            u.name AS author_name,
+            u.avatar AS author_avatar,
+            r.rating,
+            r.content,
+            r.image_url,
+            (EXTRACT(EPOCH FROM r.created_at) * 1000)::bigint AS created_at
+        FROM rule_reviews r
+        JOIN users u ON u.id = r.author_id
+        WHERE r.rule_id = $1
+        ORDER BY r.created_at DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(rule_uuid)
+    .bind(limit)
+    .fetch_all(&persistence.pool)
+    .await
+    .map_err(AppError::DatabaseError)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| RuleReview {
+            id: row.get("id"),
+            author_name: row.get("author_name"),
+            author_avatar: row.get("author_avatar"),
+            rating: row.get::<i16, _>("rating") as u8,
+            content: row.get("content"),
+            image_url: row.get::<Option<String>, _>("image_url"),
+            created_at: row.get("created_at"),
+        })
+        .collect())
+}
+
+pub async fn create_review(
+    TokenClaims { user_id, .. }: TokenClaims,
+    State(user_repo): State<std::sync::Arc<UserRepository>>,
+    State(persistence): State<RulePersistence>,
+    State(store): State<RuleStore>,
+    Path(rule_id): Path<String>,
+    Json(payload): Json<CreateReviewRequest>,
+) -> Result<Json<ApiResponse<RuleReview>>, AppError> {
+    if payload.rating == 0 || payload.rating > 5 {
+        return Err(AppError::InvalidInput("评分必须在 1 到 5 之间".to_string()));
+    }
+
+    // 校验规则存在
+    {
+        let guard = store.read().await;
+        if !guard.published.contains_key(&rule_id) {
+            return Err(AppError::NotFound);
+        }
+    }
+
+    let rule_uuid = extract_rule_uuid(&rule_id)?;
+    let review_id = uuid::Uuid::new_v4();
+    let content = payload.content.trim().to_string();
+    let image_url = payload
+        .image_url
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    sqlx::query(
+        r#"
+        INSERT INTO rule_reviews (id, rule_id, author_id, rating, content, image_url)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (rule_id, author_id) DO UPDATE SET
+            rating = EXCLUDED.rating,
+            content = EXCLUDED.content,
+            image_url = EXCLUDED.image_url,
+            updated_at = CURRENT_TIMESTAMP
+        "#,
+    )
+    .bind(review_id)
+    .bind(rule_uuid)
+    .bind(user_id.0)
+    .bind(payload.rating as i16)
+    .bind(&content)
+    .bind(image_url.as_deref())
+    .execute(&persistence.pool)
+    .await
+    .map_err(AppError::DatabaseError)?;
+
+    // 查回评价者的展示名 (用户可能没填 avatar)
+    let user = user_repo
+        .find_by_id(&user_id)
+        .await?
+        .ok_or(AppError::Unauthorized("未登录".to_string()))?;
+
+    let returned = RuleReview {
+        id: review_id.to_string(),
+        author_name: user.name,
+        author_avatar: user.avatar,
+        rating: payload.rating,
+        content,
+        image_url,
+        created_at: now_millis(),
+    };
+    Ok(Json(ApiResponse::success(returned)))
+}
+
+fn now_millis() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,10 @@ async fn main() {
             get(market::list_rooms_for_rule),
         )
         .route(
+            "/api/rules/published/{rule_id}/reviews",
+            post(market::create_review),
+        )
+        .route(
             "/api/rules/developers/{developer_id}/rules",
             get(market::list_developer_rules),
         )


### PR DESCRIPTION
见 #116。

新增 POST /api/rules/published/{rule_id}/reviews，并在已发布规则列表 / 开发者规则列表 / 规则详情中聚合平均评分与评价数；详情接口附带返回最近 20 条评价。

Closes #116