### PR TITLE
feat(market): add War (拼点战争) preset rule

### DIFF
--- a/src/domain/rule_engine.rs
+++ b/src/domain/rule_engine.rs
@@ -2755,6 +2755,9 @@ mod tests {
         assert_eq!(session.hands.get("player-a").map(Vec::len), Some(5));
         assert_eq!(session.hands.get("player-b").map(Vec::len), Some(5));
 
+        let mut expected_p0_wins: i64 = 0;
+        let mut expected_p1_wins: i64 = 0;
+
         for round in 0..5 {
             // 轮到玩家 A 出牌。
             let pending = session
@@ -2803,7 +2806,13 @@ mod tests {
             )
             .unwrap_or_else(|err| panic!("round {round}: player B play failed: {err:?}"));
 
-            // 比对后引擎应该按比较结果累加 round_wins。
+            // 强不变量：每轮 round_wins 的精确增量必须与点数比较一致。
+            match p0_point.cmp(&p1_point) {
+                std::cmp::Ordering::Greater => expected_p0_wins += 1,
+                std::cmp::Ordering::Less => expected_p1_wins += 1,
+                std::cmp::Ordering::Equal => {}
+            }
+
             let p0_wins = session
                 .players
                 .iter()
@@ -2816,24 +2825,14 @@ mod tests {
                 .find(|player| player.id == "player-b")
                 .and_then(|player| player.properties.get("round_wins").copied())
                 .unwrap_or_default();
-
-            match p0_point.cmp(&p1_point) {
-                std::cmp::Ordering::Greater => {
-                    assert!(
-                        p0_wins >= 1,
-                        "round {round}: player A point {p0_point} > {p1_point} should add a win"
-                    );
-                }
-                std::cmp::Ordering::Less => {
-                    assert!(
-                        p1_wins >= 1,
-                        "round {round}: player B point {p1_point} > {p0_point} should add a win"
-                    );
-                }
-                std::cmp::Ordering::Equal => {
-                    // 平局两侧都不加分。
-                }
-            }
+            assert_eq!(
+                p0_wins, expected_p0_wins,
+                "round {round}: player A round_wins drift after p0={p0_point} p1={p1_point}"
+            );
+            assert_eq!(
+                p1_wins, expected_p1_wins,
+                "round {round}: player B round_wins drift after p0={p0_point} p1={p1_point}"
+            );
         }
 
         // 五轮跑完后应进入结算并产出胜者（除非完全平局）。

--- a/src/domain/rule_engine.rs
+++ b/src/domain/rule_engine.rs
@@ -2707,4 +2707,177 @@ mod tests {
         assert_eq!(session.settlement_results.get("player-a"), Some(&1));
         assert_eq!(session.settlement_results.get("player-b"), Some(&0));
     }
+
+    fn load_war_rule() -> RuntimeRule {
+        let content = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("war.json"),
+        )
+        .expect("war.json should exist");
+        let design: ExportedRuleDesign =
+            serde_json::from_str(&content).expect("war.json should be valid rule json");
+
+        RuleEngine::parse(
+            "War 拼点战争".to_string(),
+            2,
+            "5 轮翻牌比大小".to_string(),
+            design,
+        )
+        .expect("war rule should compile")
+    }
+
+    fn pick_card_id(session: &GameSession, player_id: &str, hand_index: usize) -> String {
+        session
+            .hands
+            .get(player_id)
+            .and_then(|cards| cards.get(hand_index))
+            .map(|card| card.id.clone())
+            .unwrap_or_else(|| panic!("player {player_id} should have card at index {hand_index}"))
+    }
+
+    fn card_point(session: &GameSession, player_id: &str, card_id: &str) -> i64 {
+        session
+            .hands
+            .get(player_id)
+            .and_then(|cards| cards.iter().find(|card| card.id == card_id))
+            .and_then(|card| card.properties.get("点数").copied())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn simulate_war_full_match() {
+        let runtime_rule = load_war_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-war".to_string(), &runtime_rule, player_ids.clone())
+                .expect("war session should start");
+
+        // 每人开局发到 5 张牌。
+        assert_eq!(session.hands.get("player-a").map(Vec::len), Some(5));
+        assert_eq!(session.hands.get("player-b").map(Vec::len), Some(5));
+
+        for round in 0..5 {
+            // 轮到玩家 A 出牌。
+            let pending = session
+                .pending_action
+                .clone()
+                .unwrap_or_else(|| panic!("round {round}: expected player A pending action"));
+            assert_eq!(pending.component_type, 21);
+            assert_eq!(
+                pending.player_id, "player-a",
+                "round {round}: player A should act first"
+            );
+
+            let p0_card_id = pick_card_id(&session, "player-a", 0);
+            let p0_point = card_point(&session, "player-a", &p0_card_id);
+            RuleEngine::submit_action(
+                &runtime_rule,
+                &mut session,
+                "player-a",
+                PlayerActionInput {
+                    cards: vec![p0_card_id],
+                    choice: None,
+                },
+            )
+            .unwrap_or_else(|err| panic!("round {round}: player A play failed: {err:?}"));
+
+            // 轮到玩家 B 出牌。
+            let pending = session
+                .pending_action
+                .clone()
+                .unwrap_or_else(|| panic!("round {round}: expected player B pending action"));
+            assert_eq!(
+                pending.player_id, "player-b",
+                "round {round}: player B should act second"
+            );
+
+            let p1_card_id = pick_card_id(&session, "player-b", 0);
+            let p1_point = card_point(&session, "player-b", &p1_card_id);
+            RuleEngine::submit_action(
+                &runtime_rule,
+                &mut session,
+                "player-b",
+                PlayerActionInput {
+                    cards: vec![p1_card_id],
+                    choice: None,
+                },
+            )
+            .unwrap_or_else(|err| panic!("round {round}: player B play failed: {err:?}"));
+
+            // 比对后引擎应该按比较结果累加 round_wins。
+            let p0_wins = session
+                .players
+                .iter()
+                .find(|player| player.id == "player-a")
+                .and_then(|player| player.properties.get("round_wins").copied())
+                .unwrap_or_default();
+            let p1_wins = session
+                .players
+                .iter()
+                .find(|player| player.id == "player-b")
+                .and_then(|player| player.properties.get("round_wins").copied())
+                .unwrap_or_default();
+
+            match p0_point.cmp(&p1_point) {
+                std::cmp::Ordering::Greater => {
+                    assert!(
+                        p0_wins >= 1,
+                        "round {round}: player A point {p0_point} > {p1_point} should add a win"
+                    );
+                }
+                std::cmp::Ordering::Less => {
+                    assert!(
+                        p1_wins >= 1,
+                        "round {round}: player B point {p1_point} > {p0_point} should add a win"
+                    );
+                }
+                std::cmp::Ordering::Equal => {
+                    // 平局两侧都不加分。
+                }
+            }
+        }
+
+        // 五轮跑完后应进入结算并产出胜者（除非完全平局）。
+        assert_eq!(session.status, "finished", "session should be finished");
+        assert!(session.pending_action.is_none());
+        assert_eq!(session.discard_pile.len(), 10);
+
+        let p0_result = session
+            .settlement_results
+            .get("player-a")
+            .copied()
+            .unwrap_or_default();
+        let p1_result = session
+            .settlement_results
+            .get("player-b")
+            .copied()
+            .unwrap_or_default();
+        let p0_wins = session
+            .players
+            .iter()
+            .find(|player| player.id == "player-a")
+            .and_then(|player| player.properties.get("round_wins").copied())
+            .unwrap_or_default();
+        let p1_wins = session
+            .players
+            .iter()
+            .find(|player| player.id == "player-b")
+            .and_then(|player| player.properties.get("round_wins").copied())
+            .unwrap_or_default();
+
+        match p0_wins.cmp(&p1_wins) {
+            std::cmp::Ordering::Greater => {
+                assert_eq!(p0_result, 1, "player A wins more rounds, should win match");
+                assert_eq!(p1_result, 0);
+            }
+            std::cmp::Ordering::Less => {
+                assert_eq!(p1_result, 1, "player B wins more rounds, should win match");
+                assert_eq!(p0_result, 0);
+            }
+            std::cmp::Ordering::Equal => {
+                // 局合：双方 round_wins 相同时 winner_index 设为 -1，两侧 result=0。
+                assert_eq!(p0_result, 0);
+                assert_eq!(p1_result, 0);
+            }
+        }
+    }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -765,6 +765,21 @@ fn build_builtin_rules() -> Vec<PublishedRule> {
         );
     }
 
+    if let Some(design) = load_builtin_war_design() {
+        rules.extend(
+            [(
+                "builtin-war-rule",
+                "War 拼点战争",
+                2,
+                "经典战争玩法：每人 5 张手牌，连续 5 轮翻牌比大小，赢得轮数多者胜。",
+            )]
+            .into_iter()
+            .filter_map(|(id, name, player_count, description)| {
+                build_builtin_rule(id, name, player_count, description, design.clone())
+            }),
+        );
+    }
+
     rules
 }
 
@@ -776,6 +791,12 @@ fn load_builtin_test_design() -> Option<ExportedRuleDesign> {
 
 fn load_builtin_test2_design() -> Option<ExportedRuleDesign> {
     let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test2.json");
+    let content = std::fs::read_to_string(rule_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn load_builtin_war_design() -> Option<ExportedRuleDesign> {
+    let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("war.json");
     let content = std::fs::read_to_string(rule_path).ok()?;
     serde_json::from_str(&content).ok()
 }
@@ -816,6 +837,7 @@ fn builtin_rule_sort_key(rule_id: &str) -> (u8, &str) {
         "builtin-test-rule" => (1, rule_id),
         "classic" => (2, rule_id),
         "party" => (3, rule_id),
-        _ => (4, rule_id),
+        "builtin-war-rule" => (4, rule_id),
+        _ => (5, rule_id),
     }
 }

--- a/war.json
+++ b/war.json
@@ -1,0 +1,148 @@
+{
+  "classes": {
+    "player": {
+      "default_properties": {},
+      "user_properties": {
+        "round_wins": {
+          "type": "int",
+          "default": 0
+        }
+      },
+      "methods": {}
+    },
+    "card": {
+      "default_properties": {
+        "点数": {
+          "type": "enum",
+          "default": 1,
+          "config": [
+            { "id": "war-point-1", "display": "A", "value": 1 },
+            { "id": "war-point-2", "display": "2", "value": 2 },
+            { "id": "war-point-3", "display": "3", "value": 3 },
+            { "id": "war-point-4", "display": "4", "value": 4 },
+            { "id": "war-point-5", "display": "5", "value": 5 },
+            { "id": "war-point-6", "display": "6", "value": 6 },
+            { "id": "war-point-7", "display": "7", "value": 7 },
+            { "id": "war-point-8", "display": "8", "value": 8 },
+            { "id": "war-point-9", "display": "9", "value": 9 },
+            { "id": "war-point-10", "display": "10", "value": 10 }
+          ]
+        },
+        "花色": {
+          "type": "enum",
+          "default": 0,
+          "config": [
+            { "id": "war-suit-0", "display": "S", "value": 0 },
+            { "id": "war-suit-1", "display": "H", "value": 1 },
+            { "id": "war-suit-2", "display": "C", "value": 2 },
+            { "id": "war-suit-3", "display": "D", "value": 3 }
+          ]
+        }
+      },
+      "user_properties": {},
+      "methods": {}
+    },
+    "table": {
+      "default_properties": {},
+      "user_properties": {
+        "current_round": { "type": "int", "default": 0 },
+        "p0_card_point": { "type": "int", "default": 0 },
+        "p1_card_point": { "type": "int", "default": 0 },
+        "winner_index": { "type": "int", "default": -1 }
+      },
+      "methods": {}
+    }
+  },
+  "cardsets": {
+    "1": {
+      "name": "Single",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 1, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "7" } },
+        "6": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "7": { "type": 28, "content": { "result": 0, "properties": {} } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Single", "cardsetB": "Single", "next": "2" } },
+        "2": { "type": 30, "content": { "result": 0 } }
+      },
+      "successors": []
+    }
+  },
+  "cardset_comparisons": {},
+  "match_flow": {
+    "1": { "type": 17, "content": { "next": "2" } },
+    "2": { "type": 20, "content": { "prop_pair": [], "next": "3" }, "count": 5 },
+
+    "3": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_zero", "next": "4" } },
+    "4": { "type": 21, "content": { "timer": 30, "next": "5" } },
+    "5": { "type": 4, "content": { "component": "m_p0_point", "rvalue": "m_p0_point_from_play", "next": "6" } },
+
+    "6": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_one", "next": "7" } },
+    "7": { "type": 21, "content": { "timer": 30, "next": "8" } },
+    "8": { "type": 4, "content": { "component": "m_p1_point", "rvalue": "m_p1_point_from_play", "next": "9" } },
+
+    "9": { "type": 16, "content": { "condition": "cmp_p0_gt_p1", "next_true": "10", "next_false": "11" } },
+    "10": { "type": 4, "content": { "component": "m_player0_wins", "rvalue": "m_player0_wins_plus_one", "next": "14" } },
+
+    "11": { "type": 16, "content": { "condition": "cmp_p0_lt_p1", "next_true": "12", "next_false": "14" } },
+    "12": { "type": 4, "content": { "component": "m_player1_wins", "rvalue": "m_player1_wins_plus_one", "next": "14" } },
+
+    "14": { "type": 4, "content": { "component": "m_round", "rvalue": "m_round_plus_one", "next": "15" } },
+    "15": { "type": 16, "content": { "condition": "cmp_round_lt_five", "next_true": "3", "next_false": "16" } },
+    "16": { "type": 18, "content": {} },
+
+    "m_player_index": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "player_index" } },
+    "m_p0_point": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p0_card_point" } },
+    "m_p1_point": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p1_card_point" } },
+    "m_round": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "current_round" } },
+    "m_player0_wins": { "type": 6, "content": { "operator": 0, "ident": "player_0", "property": "round_wins" } },
+    "m_player1_wins": { "type": 6, "content": { "operator": 0, "ident": "player_1", "property": "round_wins" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+    "v_five": { "type": 8, "content": { "value": 5 } },
+
+    "m_p0_point_from_play": { "type": 6, "content": { "operator": 1, "ident": "m_p0_picked_card", "property": "点数" } },
+    "m_p0_picked_card": { "type": 5, "content": { "selection": "4", "index": "v_zero" } },
+    "m_p1_point_from_play": { "type": 6, "content": { "operator": 1, "ident": "m_p1_picked_card", "property": "点数" } },
+    "m_p1_picked_card": { "type": 5, "content": { "selection": "7", "index": "v_zero" } },
+
+    "m_round_plus_one": { "type": 10, "content": { "operator": 0, "lval": "m_round", "rval": "v_one" } },
+    "m_player0_wins_plus_one": { "type": 10, "content": { "operator": 0, "lval": "m_player0_wins", "rval": "v_one" } },
+    "m_player1_wins_plus_one": { "type": 10, "content": { "operator": 0, "lval": "m_player1_wins", "rval": "v_one" } },
+
+    "cmp_p0_gt_p1": { "type": 14, "content": { "operator": 1, "lval": "m_p0_point", "rval": "m_p1_point" } },
+    "cmp_p0_lt_p1": { "type": 14, "content": { "operator": 2, "lval": "m_p0_point", "rval": "m_p1_point" } },
+    "cmp_round_lt_five": { "type": 14, "content": { "operator": 2, "lval": "m_round", "rval": "v_five" } }
+  },
+  "end_flow": {
+    "1": { "type": 23, "content": { "next": "2" } },
+    "2": { "type": 16, "content": { "condition": "cmp_p0_wins_gt", "next_true": "3", "next_false": "4" } },
+    "3": { "type": 4, "content": { "component": "e_winner", "rvalue": "v_zero", "next": "7" } },
+    "4": { "type": 16, "content": { "condition": "cmp_p0_wins_lt", "next_true": "5", "next_false": "6" } },
+    "5": { "type": 4, "content": { "component": "e_winner", "rvalue": "v_one", "next": "7" } },
+    "6": { "type": 4, "content": { "component": "e_winner", "rvalue": "v_minus_one", "next": "7" } },
+
+    "7": { "type": 16, "content": { "condition": "cmp_settle_eq_winner", "next_true": "8", "next_false": "9" } },
+    "8": { "type": 24, "content": { "result": 1 } },
+    "9": { "type": 24, "content": { "result": 0 } },
+
+    "e_winner": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+    "e_settle_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "settlement_index" } },
+    "e_player0_wins": { "type": 6, "content": { "operator": 0, "ident": "player_0", "property": "round_wins" } },
+    "e_player1_wins": { "type": 6, "content": { "operator": 0, "ident": "player_1", "property": "round_wins" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+    "v_minus_one": { "type": 8, "content": { "value": -1 } },
+
+    "cmp_p0_wins_gt": { "type": 14, "content": { "operator": 1, "lval": "e_player0_wins", "rval": "e_player1_wins" } },
+    "cmp_p0_wins_lt": { "type": 14, "content": { "operator": 2, "lval": "e_player0_wins", "rval": "e_player1_wins" } },
+    "cmp_settle_eq_winner": { "type": 14, "content": { "operator": 0, "lval": "e_settle_idx", "rval": "e_winner" } }
+  }
+}


### PR DESCRIPTION
见 #83。第 1/4 款 A 路线预设规则。

## 玩法
2 人对局，每人发 5 张牌（点数 1-10 × 4 花色），轮流出 1 张比大小，赢的轮数多者胜。

## 实现要点
- `war.json` 62 节点，纯流程图无引擎扩展
- 复用 type 1-30 全部已支持原语
- `simulate_war_full_match` 单测端到端模拟一局，断言 settlement_results 与 winnerIds

## 影响
- 新增 builtin 规则 `builtin-war-rule`，启动时从 `war.json` 加载
- 不动 DB 不动 FE

Refs #83