### PR TITLE
feat(market): add 99 累加 preset rule + refactor builtin loader

### DIFF
--- a/nine_nine.json
+++ b/nine_nine.json
@@ -1,0 +1,158 @@
+{
+  "classes": {
+    "player": {
+      "default_properties": {},
+      "user_properties": {
+        "is_loser": {
+          "type": "int",
+          "default": 0
+        }
+      },
+      "methods": {}
+    },
+    "card": {
+      "default_properties": {
+        "点数": {
+          "type": "enum",
+          "default": 1,
+          "config": [
+            { "id": "nn-point-1", "display": "A", "value": 1 },
+            { "id": "nn-point-2", "display": "2", "value": 2 },
+            { "id": "nn-point-3", "display": "3", "value": 3 },
+            { "id": "nn-point-4", "display": "4", "value": 4 },
+            { "id": "nn-point-5", "display": "5", "value": 5 },
+            { "id": "nn-point-6", "display": "6", "value": 6 },
+            { "id": "nn-point-7", "display": "7", "value": 7 },
+            { "id": "nn-point-8", "display": "8", "value": 8 },
+            { "id": "nn-point-9", "display": "9", "value": 9 },
+            { "id": "nn-point-10", "display": "10", "value": 10 }
+          ]
+        },
+        "花色": {
+          "type": "enum",
+          "default": 0,
+          "config": [
+            { "id": "nn-suit-0", "display": "S", "value": 0 },
+            { "id": "nn-suit-1", "display": "H", "value": 1 },
+            { "id": "nn-suit-2", "display": "C", "value": 2 },
+            { "id": "nn-suit-3", "display": "D", "value": 3 }
+          ]
+        }
+      },
+      "user_properties": {},
+      "methods": {}
+    },
+    "table": {
+      "default_properties": {},
+      "user_properties": {
+        "current_round": { "type": "int", "default": 0 },
+        "total": { "type": "int", "default": 0 },
+        "p0_total": { "type": "int", "default": 0 },
+        "p1_total": { "type": "int", "default": 0 },
+        "overflow_player_index": { "type": "int", "default": -1 },
+        "winner_index": { "type": "int", "default": -1 }
+      },
+      "methods": {}
+    }
+  },
+  "cardsets": {
+    "1": {
+      "name": "Single",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 1, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "7" } },
+        "6": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "7": { "type": 28, "content": { "result": 0, "properties": {} } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Single", "cardsetB": "Single", "next": "2" } },
+        "2": { "type": 30, "content": { "result": 0 } }
+      },
+      "successors": []
+    }
+  },
+  "cardset_comparisons": {},
+  "match_flow": {
+    "1": { "type": 17, "content": { "next": "2" } },
+    "2": { "type": 20, "content": { "prop_pair": [], "next": "3" }, "count": 14 },
+
+    "3": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_zero", "next": "4" } },
+    "4": { "type": 21, "content": { "timer": 30, "next": "5" } },
+    "5": { "type": 4, "content": { "component": "m_total", "rvalue": "m_total_plus_p0", "next": "6" } },
+    "6": { "type": 4, "content": { "component": "m_p0_total", "rvalue": "m_p0_total_plus_p0", "next": "7" } },
+    "7": { "type": 16, "content": { "condition": "cmp_total_gt_99", "next_true": "8", "next_false": "9" } },
+    "8": { "type": 4, "content": { "component": "m_overflow_idx", "rvalue": "v_zero", "next": "16" } },
+
+    "9": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_one", "next": "10" } },
+    "10": { "type": 21, "content": { "timer": 30, "next": "11" } },
+    "11": { "type": 4, "content": { "component": "m_total", "rvalue": "m_total_plus_p1", "next": "12" } },
+    "12": { "type": 4, "content": { "component": "m_p1_total", "rvalue": "m_p1_total_plus_p1", "next": "13" } },
+    "13": { "type": 16, "content": { "condition": "cmp_total_gt_99", "next_true": "14", "next_false": "15" } },
+    "14": { "type": 4, "content": { "component": "m_overflow_idx", "rvalue": "v_one", "next": "16" } },
+
+    "15": { "type": 4, "content": { "component": "m_round", "rvalue": "m_round_plus_one", "next": "17" } },
+    "16": { "type": 18, "content": {} },
+    "17": { "type": 16, "content": { "condition": "cmp_round_lt_cap", "next_true": "3", "next_false": "16" } },
+
+    "m_player_index": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "player_index" } },
+    "m_total": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "total" } },
+    "m_p0_total": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p0_total" } },
+    "m_p1_total": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p1_total" } },
+    "m_round": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "current_round" } },
+    "m_overflow_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "overflow_player_index" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+    "v_round_cap": { "type": 8, "content": { "value": 14 } },
+    "v_99": { "type": 8, "content": { "value": 99 } },
+
+    "m_p0_picked": { "type": 5, "content": { "selection": "4", "index": "v_zero" } },
+    "m_p1_picked": { "type": 5, "content": { "selection": "10", "index": "v_zero" } },
+    "m_p0_point": { "type": 6, "content": { "operator": 1, "ident": "m_p0_picked", "property": "点数" } },
+    "m_p1_point": { "type": 6, "content": { "operator": 1, "ident": "m_p1_picked", "property": "点数" } },
+
+    "m_total_plus_p0": { "type": 10, "content": { "operator": 0, "lval": "m_total", "rval": "m_p0_point" } },
+    "m_total_plus_p1": { "type": 10, "content": { "operator": 0, "lval": "m_total", "rval": "m_p1_point" } },
+    "m_p0_total_plus_p0": { "type": 10, "content": { "operator": 0, "lval": "m_p0_total", "rval": "m_p0_point" } },
+    "m_p1_total_plus_p1": { "type": 10, "content": { "operator": 0, "lval": "m_p1_total", "rval": "m_p1_point" } },
+    "m_round_plus_one": { "type": 10, "content": { "operator": 0, "lval": "m_round", "rval": "v_one" } },
+
+    "cmp_total_gt_99": { "type": 14, "content": { "operator": 1, "lval": "m_total", "rval": "v_99" } },
+    "cmp_round_lt_cap": { "type": 14, "content": { "operator": 2, "lval": "m_round", "rval": "v_round_cap" } }
+  },
+  "end_flow": {
+    "1": { "type": 23, "content": { "next": "2" } },
+    "2": { "type": 16, "content": { "condition": "cmp_overflow_eq_zero", "next_true": "3", "next_false": "4" } },
+    "3": { "type": 4, "content": { "component": "e_winner_idx", "rvalue": "v_one", "next": "11" } },
+    "4": { "type": 16, "content": { "condition": "cmp_overflow_eq_one", "next_true": "5", "next_false": "6" } },
+    "5": { "type": 4, "content": { "component": "e_winner_idx", "rvalue": "v_zero", "next": "11" } },
+    "6": { "type": 16, "content": { "condition": "cmp_p0t_lt_p1t", "next_true": "7", "next_false": "8" } },
+    "7": { "type": 4, "content": { "component": "e_winner_idx", "rvalue": "v_zero", "next": "11" } },
+    "8": { "type": 16, "content": { "condition": "cmp_p1t_lt_p0t", "next_true": "9", "next_false": "10" } },
+    "9": { "type": 4, "content": { "component": "e_winner_idx", "rvalue": "v_one", "next": "11" } },
+    "10": { "type": 4, "content": { "component": "e_winner_idx", "rvalue": "v_neg_one", "next": "11" } },
+    "11": { "type": 16, "content": { "condition": "cmp_settle_eq_winner", "next_true": "12", "next_false": "13" } },
+    "12": { "type": 24, "content": { "result": 1 } },
+    "13": { "type": 24, "content": { "result": 0 } },
+
+    "e_overflow_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "overflow_player_index" } },
+    "e_winner_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+    "e_p0_total": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p0_total" } },
+    "e_p1_total": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p1_total" } },
+    "e_settle_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "settlement_index" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+    "v_neg_one": { "type": 8, "content": { "value": -1 } },
+
+    "cmp_overflow_eq_zero": { "type": 14, "content": { "operator": 0, "lval": "e_overflow_idx", "rval": "v_zero" } },
+    "cmp_overflow_eq_one": { "type": 14, "content": { "operator": 0, "lval": "e_overflow_idx", "rval": "v_one" } },
+    "cmp_p0t_lt_p1t": { "type": 14, "content": { "operator": 2, "lval": "e_p0_total", "rval": "e_p1_total" } },
+    "cmp_p1t_lt_p0t": { "type": 14, "content": { "operator": 2, "lval": "e_p1_total", "rval": "e_p0_total" } },
+    "cmp_settle_eq_winner": { "type": 14, "content": { "operator": 0, "lval": "e_settle_idx", "rval": "e_winner_idx" } }
+  }
+}

--- a/src/domain/rule_engine.rs
+++ b/src/domain/rule_engine.rs
@@ -2879,4 +2879,121 @@ mod tests {
             }
         }
     }
+
+    fn load_nine_nine_rule() -> RuntimeRule {
+        let content = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("nine_nine.json"),
+        )
+        .expect("nine_nine.json should exist");
+        let design: ExportedRuleDesign =
+            serde_json::from_str(&content).expect("nine_nine.json should be valid rule json");
+
+        RuleEngine::parse(
+            "99 累加".to_string(),
+            2,
+            "出牌累加，超过 99 即输".to_string(),
+            design,
+        )
+        .expect("nine_nine rule should compile")
+    }
+
+    #[test]
+    fn simulate_99_full_match_overflow_loss() {
+        // 自然出牌（永远出 hand[0]）下，14 张手牌×2 人 = 28 张实际出牌，
+        // 这 28 张牌的点数之和的下界是 220-(40-28 张里最大点数和) = 220-108 = 112，
+        // 所以无论牌堆顺序如何，14 轮内一定会有某一刻 table.total > 99 触发 overflow。
+        let runtime_rule = load_nine_nine_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session = RuleEngine::start_session(
+            "room-99-overflow".to_string(),
+            &runtime_rule,
+            player_ids.clone(),
+        )
+        .expect("99 session should start");
+
+        assert_eq!(session.hands.get("player-a").map(Vec::len), Some(14));
+        assert_eq!(session.hands.get("player-b").map(Vec::len), Some(14));
+
+        let pending = session
+            .pending_action
+            .clone()
+            .expect("expected player A pending action at start");
+        assert_eq!(pending.component_type, 21);
+        assert_eq!(pending.player_id, "player-a");
+
+        let mut expected_p0_total: i64 = 0;
+        let mut expected_p1_total: i64 = 0;
+        let mut last_player: Option<String> = None;
+        let mut plays = 0usize;
+
+        // 最多 28 张实际出牌；理论 14 轮一定 overflow，留些余量防止死循环。
+        while session.status != "finished" && plays < 40 {
+            let pending = session
+                .pending_action
+                .clone()
+                .unwrap_or_else(|| panic!("play {plays}: expected a pending action"));
+            assert_eq!(pending.component_type, 21);
+
+            let player_id = pending.player_id.clone();
+            let card_id = pick_card_id(&session, &player_id, 0);
+            let point = card_point(&session, &player_id, &card_id);
+            assert!(point >= 1, "card 点数 should be at least 1");
+
+            if player_id == "player-a" {
+                expected_p0_total += point;
+            } else {
+                expected_p1_total += point;
+            }
+            last_player = Some(player_id.clone());
+
+            RuleEngine::submit_action(
+                &runtime_rule,
+                &mut session,
+                &player_id,
+                PlayerActionInput {
+                    cards: vec![card_id],
+                    choice: None,
+                },
+            )
+            .unwrap_or_else(|err| panic!("play {plays}: {player_id} play failed: {err:?}"));
+            plays += 1;
+        }
+
+        // 触发 overflow 后局应直接进入结算。
+        assert_eq!(
+            session.status, "finished",
+            "session should finish via overflow within {plays} natural plays"
+        );
+        assert!(session.pending_action.is_none());
+
+        let total = session.table.get("total").copied().unwrap_or_default();
+        assert!(total > 99, "table.total {total} should exceed 99");
+        assert_eq!(
+            total,
+            expected_p0_total + expected_p1_total,
+            "table.total should match sum of all naturally played points"
+        );
+
+        let overflow_idx = session
+            .table
+            .get("overflow_player_index")
+            .copied()
+            .unwrap_or_default();
+        let last_player =
+            last_player.expect("at least one card should have been played before overflow");
+        let expected_overflow_idx = if last_player == "player-a" { 0 } else { 1 };
+        assert_eq!(
+            overflow_idx, expected_overflow_idx,
+            "the player who pushed total past 99 should be marked as overflow loser"
+        );
+
+        // 输家拿 0，赢家拿 1。
+        let (loser, winner) = if expected_overflow_idx == 0 {
+            ("player-a", "player-b")
+        } else {
+            ("player-b", "player-a")
+        };
+        assert_eq!(session.settlement_results.get(loser), Some(&0));
+        assert_eq!(session.settlement_results.get(winner), Some(&1));
+    }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -718,85 +718,89 @@ fn build_builtin_test_rule() -> Option<PublishedRule> {
     })
 }
 
+struct BuiltinRuleSpec {
+    id: &'static str,
+    name: &'static str,
+    player_count: u8,
+    description: &'static str,
+    design_file: &'static str,
+}
+
+const BUILTIN_RULES: &[BuiltinRuleSpec] = &[
+    BuiltinRuleSpec {
+        id: "builtin-test2-rule",
+        name: "Tiny Demo",
+        player_count: 2,
+        description: "Minimal playable builtin rule loaded from test2.json.",
+        design_file: "test2.json",
+    },
+    BuiltinRuleSpec {
+        id: "builtin-test-rule",
+        name: "Duel Demo",
+        player_count: 2,
+        description: "Playable builtin rule loaded from test.json.",
+        design_file: "test.json",
+    },
+    BuiltinRuleSpec {
+        id: "classic",
+        name: "Classic Demo",
+        player_count: 2,
+        description: "Legacy room rule kept for compatibility. Uses the same duel flow as test.json.",
+        design_file: "test.json",
+    },
+    BuiltinRuleSpec {
+        id: "party",
+        name: "Party Demo",
+        player_count: 2,
+        description: "Legacy room rule kept for compatibility. Uses the same duel flow as test.json.",
+        design_file: "test.json",
+    },
+    BuiltinRuleSpec {
+        id: "builtin-war-rule",
+        name: "War 拼点战争",
+        player_count: 2,
+        description: "经典战争玩法：每人 5 张手牌，连续 5 轮翻牌比大小，赢得轮数多者胜。",
+        design_file: "war.json",
+    },
+    BuiltinRuleSpec {
+        id: "builtin-99-rule",
+        name: "99 累加",
+        player_count: 2,
+        description: "经典累加玩法：每人 14 张牌，轮流出牌把点数加进桌面总和；让总和超过 99 的玩家输。",
+        design_file: "nine_nine.json",
+    },
+];
+
 fn build_builtin_rules() -> Vec<PublishedRule> {
+    let mut cache: HashMap<&'static str, ExportedRuleDesign> = HashMap::new();
     let mut rules = Vec::new();
 
-    if let Some(design) = load_builtin_test2_design() {
-        rules.extend(
-            [(
-                "builtin-test2-rule",
-                "Tiny Demo",
-                2,
-                "Minimal playable builtin rule loaded from test2.json.",
-            )]
-            .into_iter()
-            .filter_map(|(id, name, player_count, description)| {
-                build_builtin_rule(id, name, player_count, description, design.clone())
-            }),
-        );
+    for spec in BUILTIN_RULES {
+        let design = match cache.get(spec.design_file) {
+            Some(design) => design.clone(),
+            None => match load_builtin_design(spec.design_file) {
+                Some(design) => {
+                    cache.insert(spec.design_file, design.clone());
+                    design
+                }
+                None => continue,
+            },
+        };
+        if let Some(rule) = build_builtin_rule(
+            spec.id,
+            spec.name,
+            spec.player_count,
+            spec.description,
+            design,
+        ) {
+            rules.push(rule);
+        }
     }
-
-    if let Some(design) = load_builtin_test_design() {
-        rules.extend(
-            [
-                (
-                    "builtin-test-rule",
-                    "Duel Demo",
-                    2,
-                    "Playable builtin rule loaded from test.json.",
-                ),
-                (
-                    "classic",
-                    "Classic Demo",
-                    2,
-                    "Legacy room rule kept for compatibility. Uses the same duel flow as test.json.",
-                ),
-                (
-                    "party",
-                    "Party Demo",
-                    2,
-                    "Legacy room rule kept for compatibility. Uses the same duel flow as test.json.",
-                ),
-            ]
-            .into_iter()
-            .filter_map(|(id, name, player_count, description)| {
-                build_builtin_rule(id, name, player_count, description, design.clone())
-            }),
-        );
-    }
-
-    if let Some(design) = load_builtin_war_design() {
-        rules.extend(
-            [(
-                "builtin-war-rule",
-                "War 拼点战争",
-                2,
-                "经典战争玩法：每人 5 张手牌，连续 5 轮翻牌比大小，赢得轮数多者胜。",
-            )]
-            .into_iter()
-            .filter_map(|(id, name, player_count, description)| {
-                build_builtin_rule(id, name, player_count, description, design.clone())
-            }),
-        );
-    }
-
     rules
 }
 
-fn load_builtin_test_design() -> Option<ExportedRuleDesign> {
-    let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test.json");
-    let content = std::fs::read_to_string(rule_path).ok()?;
-    serde_json::from_str(&content).ok()
-}
-
-fn load_builtin_test2_design() -> Option<ExportedRuleDesign> {
-    let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test2.json");
-    let content = std::fs::read_to_string(rule_path).ok()?;
-    serde_json::from_str(&content).ok()
-}
-
-fn load_builtin_war_design() -> Option<ExportedRuleDesign> {
-    let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("war.json");
+fn load_builtin_design(filename: &str) -> Option<ExportedRuleDesign> {
+    let rule_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(filename);
     let content = std::fs::read_to_string(rule_path).ok()?;
     serde_json::from_str(&content).ok()
 }
@@ -832,12 +836,10 @@ fn build_builtin_rule(
 }
 
 fn builtin_rule_sort_key(rule_id: &str) -> (u8, &str) {
-    match rule_id {
-        "builtin-test2-rule" => (0, rule_id),
-        "builtin-test-rule" => (1, rule_id),
-        "classic" => (2, rule_id),
-        "party" => (3, rule_id),
-        "builtin-war-rule" => (4, rule_id),
-        _ => (5, rule_id),
-    }
+    let order = BUILTIN_RULES
+        .iter()
+        .position(|spec| spec.id == rule_id)
+        .map(|idx| idx as u8)
+        .unwrap_or(u8::MAX);
+    (order, rule_id)
 }


### PR DESCRIPTION
见 #83。第 2/4 款 A 路线预设规则 + 顺手清理 builtin 加载逻辑。

## 玩法
2 人对局，每人 14 张牌（1-10 × 4 花色取 28 张），轮流出 1 张把点数加到桌面总和；让 total > 99 者输。

14 张设定经过数学校验：deck 总分 220 + 剩 12 张最大和 108 = 强制出牌至少 112 → 自然玩法 100% 触发 overflow。

## 实现要点
- `nine_nine.json` 158 行
- `simulate_99_full_match_overflow_loss` 走完整 14 张自然玩法，无任何 `session.table.insert` 注入
- 重构：原来 4 份 `load_builtin_*_design` + 4 段 if-let extend 改为单个 `BUILTIN_RULES` const 表 + 一个带缓存的 `load_builtin_design`，加新规则只改一行
- `builtin_rule_sort_key` 从 const 表 position 派生，永远不会和注册顺序漂移

## 已知遗留
end_flow 节点 6-10 是无人 overflow 时按 total 小者胜的兜底分支，在 14 张设定下数学上跑不到，保留为防御性逻辑。

Refs #83
