### PR TITLE
feat(market): add 大老二极简版 preset rule

### DIFF
--- a/big_two.json
+++ b/big_two.json
@@ -1,0 +1,232 @@
+{
+  "classes": {
+    "player": {
+      "default_properties": {},
+      "user_properties": {},
+      "methods": {}
+    },
+    "card": {
+      "default_properties": {
+        "点数": {
+          "type": "enum",
+          "default": 1,
+          "config": [
+            { "id": "bigtwo-point-1", "display": "A", "value": 1 },
+            { "id": "bigtwo-point-2", "display": "2", "value": 2 },
+            { "id": "bigtwo-point-3", "display": "3", "value": 3 },
+            { "id": "bigtwo-point-4", "display": "4", "value": 4 },
+            { "id": "bigtwo-point-5", "display": "5", "value": 5 },
+            { "id": "bigtwo-point-6", "display": "6", "value": 6 },
+            { "id": "bigtwo-point-7", "display": "7", "value": 7 },
+            { "id": "bigtwo-point-8", "display": "8", "value": 8 },
+            { "id": "bigtwo-point-9", "display": "9", "value": 9 },
+            { "id": "bigtwo-point-10", "display": "10", "value": 10 },
+            { "id": "bigtwo-point-11", "display": "J", "value": 11 },
+            { "id": "bigtwo-point-12", "display": "Q", "value": 12 },
+            { "id": "bigtwo-point-13", "display": "K", "value": 13 }
+          ]
+        },
+        "花色": {
+          "type": "enum",
+          "default": 0,
+          "config": [
+            { "id": "bigtwo-suit-0", "display": "S", "value": 0 },
+            { "id": "bigtwo-suit-1", "display": "H", "value": 1 },
+            { "id": "bigtwo-suit-2", "display": "C", "value": 2 },
+            { "id": "bigtwo-suit-3", "display": "D", "value": 3 }
+          ]
+        }
+      },
+      "user_properties": {},
+      "methods": {}
+    },
+    "table": {
+      "default_properties": {},
+      "user_properties": {
+        "winner_index": { "type": "int", "default": -1 }
+      },
+      "methods": {}
+    }
+  },
+  "cardsets": {
+    "1": {
+      "name": "Single",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 1, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "7" } },
+        "6": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "7": { "type": 28, "content": { "result": 0, "properties": {} } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Single", "cardsetB": "Single", "next": "2" } },
+        "2": { "type": 5, "content": { "selection": "A", "index": "v_zero", "next": "3" } },
+        "3": { "type": 6, "content": { "operator": 1, "ident": "2", "property": "点数", "next": "4" } },
+        "4": { "type": 5, "content": { "selection": "B", "index": "v_zero", "next": "5" } },
+        "5": { "type": 6, "content": { "operator": 1, "ident": "4", "property": "点数", "next": "6" } },
+        "6": { "type": 14, "content": { "operator": 1, "lval": "3", "rval": "5", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "8", "next_false": "9" } },
+        "8": { "type": 30, "content": { "result": 0 } },
+        "9": { "type": 30, "content": { "result": 1 } },
+        "v_zero": { "type": 8, "content": { "value": 0 } }
+      },
+      "successors": []
+    },
+    "2": {
+      "name": "Pair",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 2, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "fail" } },
+        "6": { "type": 14, "content": { "operator": 0, "lval": "c0p", "rval": "c1p", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "ok", "next_false": "fail" } },
+        "ok": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "fail": { "type": 28, "content": { "result": 0, "properties": {} } },
+        "c0": { "type": 5, "content": { "selection": "cards", "index": "v_zero" } },
+        "c1": { "type": 5, "content": { "selection": "cards", "index": "v_one" } },
+        "c0p": { "type": 6, "content": { "operator": 1, "ident": "c0", "property": "点数" } },
+        "c1p": { "type": 6, "content": { "operator": 1, "ident": "c1", "property": "点数" } },
+        "v_zero": { "type": 8, "content": { "value": 0 } },
+        "v_one": { "type": 8, "content": { "value": 1 } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Pair", "cardsetB": "Pair", "next": "2" } },
+        "2": { "type": 5, "content": { "selection": "A", "index": "v_zero", "next": "3" } },
+        "3": { "type": 6, "content": { "operator": 1, "ident": "2", "property": "点数", "next": "4" } },
+        "4": { "type": 5, "content": { "selection": "B", "index": "v_zero", "next": "5" } },
+        "5": { "type": 6, "content": { "operator": 1, "ident": "4", "property": "点数", "next": "6" } },
+        "6": { "type": 14, "content": { "operator": 1, "lval": "3", "rval": "5", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "8", "next_false": "9" } },
+        "8": { "type": 30, "content": { "result": 0 } },
+        "9": { "type": 30, "content": { "result": 1 } },
+        "v_zero": { "type": 8, "content": { "value": 0 } }
+      },
+      "successors": []
+    },
+    "3": {
+      "name": "Triple",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 3, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "fail" } },
+        "6": { "type": 12, "content": { "operator": 0, "lval": "eq01", "rval": "eq12", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "ok", "next_false": "fail" } },
+        "ok": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "fail": { "type": 28, "content": { "result": 0, "properties": {} } },
+        "eq01": { "type": 14, "content": { "operator": 0, "lval": "c0p", "rval": "c1p" } },
+        "eq12": { "type": 14, "content": { "operator": 0, "lval": "c1p", "rval": "c2p" } },
+        "c0": { "type": 5, "content": { "selection": "cards", "index": "v_zero" } },
+        "c1": { "type": 5, "content": { "selection": "cards", "index": "v_one" } },
+        "c2": { "type": 5, "content": { "selection": "cards", "index": "v_two" } },
+        "c0p": { "type": 6, "content": { "operator": 1, "ident": "c0", "property": "点数" } },
+        "c1p": { "type": 6, "content": { "operator": 1, "ident": "c1", "property": "点数" } },
+        "c2p": { "type": 6, "content": { "operator": 1, "ident": "c2", "property": "点数" } },
+        "v_zero": { "type": 8, "content": { "value": 0 } },
+        "v_one": { "type": 8, "content": { "value": 1 } },
+        "v_two": { "type": 8, "content": { "value": 2 } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Triple", "cardsetB": "Triple", "next": "2" } },
+        "2": { "type": 5, "content": { "selection": "A", "index": "v_zero", "next": "3" } },
+        "3": { "type": 6, "content": { "operator": 1, "ident": "2", "property": "点数", "next": "4" } },
+        "4": { "type": 5, "content": { "selection": "B", "index": "v_zero", "next": "5" } },
+        "5": { "type": 6, "content": { "operator": 1, "ident": "4", "property": "点数", "next": "6" } },
+        "6": { "type": 14, "content": { "operator": 1, "lval": "3", "rval": "5", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "8", "next_false": "9" } },
+        "8": { "type": 30, "content": { "result": 0 } },
+        "9": { "type": 30, "content": { "result": 1 } },
+        "v_zero": { "type": 8, "content": { "value": 0 } }
+      },
+      "successors": []
+    },
+    "4": {
+      "name": "Bomb",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 4, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "fail" } },
+        "6": { "type": 12, "content": { "operator": 0, "lval": "and_01_12", "rval": "eq23", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "ok", "next_false": "fail" } },
+        "ok": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "fail": { "type": 28, "content": { "result": 0, "properties": {} } },
+        "and_01_12": { "type": 12, "content": { "operator": 0, "lval": "eq01", "rval": "eq12" } },
+        "eq01": { "type": 14, "content": { "operator": 0, "lval": "c0p", "rval": "c1p" } },
+        "eq12": { "type": 14, "content": { "operator": 0, "lval": "c1p", "rval": "c2p" } },
+        "eq23": { "type": 14, "content": { "operator": 0, "lval": "c2p", "rval": "c3p" } },
+        "c0": { "type": 5, "content": { "selection": "cards", "index": "v_zero" } },
+        "c1": { "type": 5, "content": { "selection": "cards", "index": "v_one" } },
+        "c2": { "type": 5, "content": { "selection": "cards", "index": "v_two" } },
+        "c3": { "type": 5, "content": { "selection": "cards", "index": "v_three" } },
+        "c0p": { "type": 6, "content": { "operator": 1, "ident": "c0", "property": "点数" } },
+        "c1p": { "type": 6, "content": { "operator": 1, "ident": "c1", "property": "点数" } },
+        "c2p": { "type": 6, "content": { "operator": 1, "ident": "c2", "property": "点数" } },
+        "c3p": { "type": 6, "content": { "operator": 1, "ident": "c3", "property": "点数" } },
+        "v_zero": { "type": 8, "content": { "value": 0 } },
+        "v_one": { "type": 8, "content": { "value": 1 } },
+        "v_two": { "type": 8, "content": { "value": 2 } },
+        "v_three": { "type": 8, "content": { "value": 3 } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Bomb", "cardsetB": "Bomb", "next": "2" } },
+        "2": { "type": 5, "content": { "selection": "A", "index": "v_zero", "next": "3" } },
+        "3": { "type": 6, "content": { "operator": 1, "ident": "2", "property": "点数", "next": "4" } },
+        "4": { "type": 5, "content": { "selection": "B", "index": "v_zero", "next": "5" } },
+        "5": { "type": 6, "content": { "operator": 1, "ident": "4", "property": "点数", "next": "6" } },
+        "6": { "type": 14, "content": { "operator": 1, "lval": "3", "rval": "5", "next": "7" } },
+        "7": { "type": 16, "content": { "condition": "6", "next_true": "8", "next_false": "9" } },
+        "8": { "type": 30, "content": { "result": 0 } },
+        "9": { "type": 30, "content": { "result": 1 } },
+        "v_zero": { "type": 8, "content": { "value": 0 } }
+      },
+      "successors": ["1", "2", "3"]
+    }
+  },
+  "cardset_comparisons": {},
+  "match_flow": {
+    "1": { "type": 17, "content": { "next": "2" } },
+    "2": { "type": 20, "content": { "prop_pair": [], "next": "3" }, "count": 8 },
+
+    "3": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_zero", "next": "4" } },
+    "4": { "type": 21, "content": { "timer": 30, "next": "5" } },
+    "5": { "type": 16, "content": { "condition": "cmp_hand_eq_zero", "next_true": "6", "next_false": "7" } },
+    "6": { "type": 4, "content": { "component": "m_winner_index", "rvalue": "m_player_index", "next": "to_end" } },
+    "to_end": { "type": 18, "content": {} },
+
+    "7": { "type": 16, "content": { "condition": "cmp_player_idx_eq_zero", "next_true": "8", "next_false": "9" } },
+    "8": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_one", "next": "4" } },
+    "9": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_zero", "next": "4" } },
+
+    "m_player_index": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "player_index" } },
+    "m_winner_index": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+    "m_hand_count": { "type": 6, "content": { "operator": 0, "ident": "玩家", "property": "手牌数" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+
+    "cmp_hand_eq_zero": { "type": 14, "content": { "operator": 0, "lval": "m_hand_count", "rval": "v_zero" } },
+    "cmp_player_idx_eq_zero": { "type": 14, "content": { "operator": 0, "lval": "m_player_index", "rval": "v_zero" } }
+  },
+  "end_flow": {
+    "1": { "type": 23, "content": { "next": "2" } },
+    "2": { "type": 16, "content": { "condition": "cmp_settle_eq_winner", "next_true": "3", "next_false": "4" } },
+    "3": { "type": 24, "content": { "result": 1 } },
+    "4": { "type": 24, "content": { "result": 0 } },
+
+    "e_settle_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "settlement_index" } },
+    "e_winner_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+
+    "cmp_settle_eq_winner": { "type": 14, "content": { "operator": 0, "lval": "e_settle_idx", "rval": "e_winner_idx" } }
+  }
+}

--- a/src/domain/rule_engine.rs
+++ b/src/domain/rule_engine.rs
@@ -2996,4 +2996,533 @@ mod tests {
         assert_eq!(session.settlement_results.get(loser), Some(&0));
         assert_eq!(session.settlement_results.get(winner), Some(&1));
     }
+
+    fn load_big_two_rule() -> RuntimeRule {
+        let content = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("big_two.json"),
+        )
+        .expect("big_two.json should exist");
+        let design: ExportedRuleDesign =
+            serde_json::from_str(&content).expect("big_two.json should be valid rule json");
+
+        RuleEngine::parse(
+            "大老二极简版".to_string(),
+            2,
+            "简化版大老二：单/对/三 + 炸弹，先出完赢。".to_string(),
+            design,
+        )
+        .expect("big_two rule should compile")
+    }
+
+    /// 把 session 的全部 52 张牌池化，按需要的点数分别取出来填给 A、B；
+    /// 剩下的丢回 session.deck，并刷新 player.手牌数。
+    /// 测试需要确定性的手牌组合，不能依赖自然发牌（HashMap 迭代顺序不定）。
+    fn force_bigtwo_hands(session: &mut GameSession, a_points: &[i64], b_points: &[i64]) {
+        let mut pool: Vec<GameCard> = Vec::new();
+        pool.append(&mut session.deck);
+        for hand in session.hands.values_mut() {
+            pool.append(hand);
+        }
+        pool.append(&mut session.discard_pile);
+
+        fn take_by_point(pool: &mut Vec<GameCard>, point: i64) -> GameCard {
+            let pos = pool
+                .iter()
+                .position(|card| card.properties.get("点数").copied().unwrap_or_default() == point)
+                .unwrap_or_else(|| panic!("pool exhausted for point {point}"));
+            pool.remove(pos)
+        }
+
+        let a_hand: Vec<GameCard> = a_points
+            .iter()
+            .map(|p| take_by_point(&mut pool, *p))
+            .collect();
+        let b_hand: Vec<GameCard> = b_points
+            .iter()
+            .map(|p| take_by_point(&mut pool, *p))
+            .collect();
+
+        session.hands.insert("player-a".to_string(), a_hand);
+        session.hands.insert("player-b".to_string(), b_hand);
+        session.deck = pool;
+
+        for player in &mut session.players {
+            let count = session
+                .hands
+                .get(&player.id)
+                .map(Vec::len)
+                .unwrap_or_default() as i64;
+            player.properties.insert("手牌数".to_string(), count);
+        }
+    }
+
+    fn find_hand_card_by_point(
+        session: &GameSession,
+        player_id: &str,
+        point: i64,
+    ) -> Option<String> {
+        session.hands.get(player_id).and_then(|cards| {
+            cards
+                .iter()
+                .find(|card| card.properties.get("点数").copied().unwrap_or_default() == point)
+                .map(|card| card.id.clone())
+        })
+    }
+
+    #[test]
+    fn simulate_bigtwo_singles_win() {
+        // A 拿 1..=8 八张严格递增的单张；B 拿 8 张 9/K 的牌可随便垫。
+        // A 每轮按递增顺序出最小可压制的单张，B 全过；A 出完 8 张应判赢。
+        let runtime_rule = load_big_two_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bigtwo-1".to_string(), &runtime_rule, player_ids)
+                .expect("big_two session should start");
+
+        force_bigtwo_hands(
+            &mut session,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[9, 9, 9, 9, 13, 13, 13, 13],
+        );
+
+        // 起始挂起动作应该是 player-a 的出牌。
+        let pending = session
+            .pending_action
+            .clone()
+            .expect("expected first pending action");
+        assert_eq!(pending.component_type, 21);
+        assert_eq!(pending.player_id, "player-a");
+
+        for point in 1i64..=8 {
+            // A 出一张该点数的单张。
+            let card_id = find_hand_card_by_point(&session, "player-a", point)
+                .unwrap_or_else(|| panic!("player-a 缺少点数 {point} 的牌"));
+            RuleEngine::submit_action(
+                &runtime_rule,
+                &mut session,
+                "player-a",
+                PlayerActionInput {
+                    cards: vec![card_id],
+                    choice: None,
+                },
+            )
+            .unwrap_or_else(|err| panic!("A play point {point} failed: {err:?}"));
+
+            // 若 A 已出完，跳过 B 的 pass —— 引擎应已进入结算。
+            if session.status == "finished" {
+                break;
+            }
+
+            // 轮到 B 时让他 pass。
+            let pending = session
+                .pending_action
+                .clone()
+                .unwrap_or_else(|| panic!("expected B pending after A point {point}"));
+            assert_eq!(pending.player_id, "player-b");
+            RuleEngine::submit_action(
+                &runtime_rule,
+                &mut session,
+                "player-b",
+                PlayerActionInput {
+                    cards: Vec::new(),
+                    choice: None,
+                },
+            )
+            .unwrap_or_else(|err| panic!("B pass after A point {point} failed: {err:?}"));
+        }
+
+        assert_eq!(session.status, "finished", "A 出完 8 张后应结算");
+        assert!(session.pending_action.is_none());
+        assert_eq!(
+            session.hands.get("player-a").map(Vec::len),
+            Some(0),
+            "A 手牌应为 0"
+        );
+        assert_eq!(
+            session.table.get("winner_index").copied(),
+            Some(0),
+            "winner_index 应为 0"
+        );
+        assert_eq!(session.settlement_results.get("player-a"), Some(&1));
+        assert_eq!(session.settlement_results.get("player-b"), Some(&0));
+    }
+
+    #[test]
+    fn simulate_bigtwo_pair_must_beat_pair() {
+        // A 拿一对 3 + 别的散牌；B 拿一对 2、一对 5、若干散牌。
+        // 流程：A 出 (3,3) → B 试 (2,2) 应被拒 → B 出 (5,5) 应成功 → A 该回合换 hand[0] pass。
+        let runtime_rule = load_big_two_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bigtwo-2".to_string(), &runtime_rule, player_ids)
+                .expect("big_two session should start");
+
+        force_bigtwo_hands(
+            &mut session,
+            // A: pair of 3 + 6 张垫牌（无需特别意义）
+            &[3, 3, 7, 8, 9, 10, 11, 12],
+            // B: pair of 2 + pair of 5 + 4 张垫牌
+            &[2, 2, 5, 5, 6, 6, 13, 13],
+        );
+
+        // A 出对 3
+        let a_cards: Vec<String> = session
+            .hands
+            .get("player-a")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(3))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(a_cards.len(), 2, "A 应该有两张 3");
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-a",
+            PlayerActionInput {
+                cards: a_cards,
+                choice: None,
+            },
+        )
+        .expect("A 应能首发对 3");
+
+        // 现在应该轮到 B。
+        let pending = session
+            .pending_action
+            .clone()
+            .expect("expected B pending after A's pair");
+        assert_eq!(pending.player_id, "player-b");
+
+        // B 试出对 2（更小） —— 必须被拒。
+        let b_small_pair: Vec<String> = session
+            .hands
+            .get("player-b")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(2))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(b_small_pair.len(), 2, "B 应该有两张 2");
+        let err = RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-b",
+            PlayerActionInput {
+                cards: b_small_pair,
+                choice: None,
+            },
+        )
+        .expect_err("更小的对子不应被允许压上一手");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("出牌必须符合当前规则的牌型优先级关系") || msg.contains("牌型"),
+            "应为牌型优先级相关错误，实际：{msg}"
+        );
+
+        // 失败后挂起动作仍是 B —— 状态没被破坏。
+        let pending = session
+            .pending_action
+            .clone()
+            .expect("拒绝后仍应保留 B 的挂起");
+        assert_eq!(pending.player_id, "player-b");
+
+        // B 改出对 5 —— 应成功。
+        let b_big_pair: Vec<String> = session
+            .hands
+            .get("player-b")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(5))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(b_big_pair.len(), 2);
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-b",
+            PlayerActionInput {
+                cards: b_big_pair,
+                choice: None,
+            },
+        )
+        .expect("B 应能用更大的对 5 压制对 3");
+
+        // 验证 last_successful_play 已经变成 B 的对 5。
+        let last = session
+            .last_successful_play
+            .as_ref()
+            .expect("应记录 B 的成功出牌");
+        assert_eq!(last.player_id, "player-b");
+        assert_eq!(last.cards.len(), 2);
+        for c in &last.cards {
+            assert_eq!(c.properties.get("点数").copied(), Some(5));
+        }
+        assert_eq!(
+            session.hands.get("player-b").map(Vec::len),
+            Some(6),
+            "B 应余 6 张"
+        );
+    }
+
+    /// 任务 1：验证 Bomb 通过 successors 能压住 Triple（跨牌型）。
+    /// 若 big_two.json 把 successors 配错（如挂到 Single 上），此测试会因
+    /// can_beat_previous_round 返回 false 而让 B 出炸弹被拒。
+    #[test]
+    fn simulate_bigtwo_bomb_beats_triple() {
+        let runtime_rule = load_big_two_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bigtwo-bomb".to_string(), &runtime_rule, player_ids)
+                .expect("big_two session should start");
+
+        // A: 三张 1 + 5 张垫牌；B: 四张 7 + 4 张垫牌。
+        force_bigtwo_hands(
+            &mut session,
+            &[1, 1, 1, 2, 3, 4, 5, 6],
+            &[7, 7, 7, 7, 8, 9, 10, 11],
+        );
+
+        // A 出三张 1（Triple）。
+        let a_triple: Vec<String> = session
+            .hands
+            .get("player-a")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(1))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(a_triple.len(), 3, "A 应该有三张 1");
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-a",
+            PlayerActionInput {
+                cards: a_triple,
+                choice: None,
+            },
+        )
+        .expect("A 应能首发三张 1");
+
+        // 轮到 B 出炸弹 7777。
+        let pending = session
+            .pending_action
+            .clone()
+            .expect("expected B pending after A's triple");
+        assert_eq!(pending.player_id, "player-b");
+
+        let b_bomb: Vec<String> = session
+            .hands
+            .get("player-b")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(7))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(b_bomb.len(), 4, "B 应该有四张 7");
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-b",
+            PlayerActionInput {
+                cards: b_bomb,
+                choice: None,
+            },
+        )
+        .expect("Bomb 应该能通过 successors 压住 Triple");
+
+        // 验证 last_successful_play 是 B 的炸弹 7777。
+        let last = session
+            .last_successful_play
+            .as_ref()
+            .expect("应记录 B 的炸弹出牌");
+        assert_eq!(last.player_id, "player-b");
+        assert_eq!(last.cards.len(), 4, "炸弹应为 4 张");
+        for c in &last.cards {
+            assert_eq!(
+                c.properties.get("点数").copied(),
+                Some(7),
+                "炸弹四张应同点数 7"
+            );
+        }
+        assert_eq!(
+            session.hands.get("player-b").map(Vec::len),
+            Some(4),
+            "B 出完炸弹应余 4 张"
+        );
+    }
+
+    /// 任务 2：首手玩家不允许 pass（cards=[] 在 last_successful_play=None 时禁止）。
+    /// 引擎保护位于 src/domain/rule_engine.rs:573-578。
+    #[test]
+    fn simulate_bigtwo_first_play_cannot_pass() {
+        let runtime_rule = load_big_two_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session = RuleEngine::start_session(
+            "room-bigtwo-firstpass".to_string(),
+            &runtime_rule,
+            player_ids,
+        )
+        .expect("big_two session should start");
+
+        // 固定手牌只是为了快速失败重现；具体点数不影响 pass 的判定。
+        force_bigtwo_hands(
+            &mut session,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[9, 9, 9, 9, 13, 13, 13, 13],
+        );
+
+        // 起手必须挂在 A 身上。
+        let pending_before = session
+            .pending_action
+            .clone()
+            .expect("expected first pending action");
+        assert_eq!(pending_before.player_id, "player-a");
+        assert!(
+            session.last_successful_play.is_none(),
+            "首手时 last_successful_play 必须为空"
+        );
+
+        // A 尝试空选择 pass —— 必须被拒。
+        let err = RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-a",
+            PlayerActionInput {
+                cards: Vec::new(),
+                choice: None,
+            },
+        )
+        .expect_err("首手玩家不应被允许 pass");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("Cannot skip before any card has been played"),
+            "应为首手禁止 pass 的错误，实际：{msg}"
+        );
+
+        // 错误返回后挂起动作仍是 A —— 不应已切到 B。
+        let pending_after = session
+            .pending_action
+            .clone()
+            .expect("拒绝后挂起动作不应被清空");
+        assert_eq!(
+            pending_after.player_id, "player-a",
+            "拒绝后回合仍应在 A 身上"
+        );
+        assert_eq!(pending_after.id, pending_before.id, "挂起节点 id 不应变化");
+        assert!(
+            session.last_successful_play.is_none(),
+            "失败的 pass 不应写入 last_successful_play"
+        );
+    }
+
+    /// 任务 3：跨牌型只能用炸弹压。Triple 既不在 Pair 的 successors 也没有
+    /// cardset_comparisons 兜底，必须被拒；之后 B 出炸弹 5555 应成功。
+    #[test]
+    fn simulate_bigtwo_cross_type_must_use_bomb() {
+        let runtime_rule = load_big_two_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bigtwo-cross".to_string(), &runtime_rule, player_ids)
+                .expect("big_two session should start");
+
+        // A: 对 3 + 6 张垫牌；B: 三张 4 + 四张 5 + 1 张垫牌。
+        force_bigtwo_hands(
+            &mut session,
+            &[3, 3, 7, 8, 9, 10, 11, 12],
+            &[4, 4, 4, 5, 5, 5, 5, 13],
+        );
+
+        // A 先出对 3。
+        let a_pair: Vec<String> = session
+            .hands
+            .get("player-a")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(3))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(a_pair.len(), 2);
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-a",
+            PlayerActionInput {
+                cards: a_pair,
+                choice: None,
+            },
+        )
+        .expect("A 应能首发对 3");
+
+        // B 尝试出 Triple 444 压 Pair —— 必须被拒（既无 successors，也无 cardset_comparisons）。
+        let b_triple: Vec<String> = session
+            .hands
+            .get("player-b")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(4))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(b_triple.len(), 3);
+        let err = RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-b",
+            PlayerActionInput {
+                cards: b_triple,
+                choice: None,
+            },
+        )
+        .expect_err("Triple 不应能压 Pair");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("出牌必须符合当前规则的牌型优先级关系") || msg.contains("牌型"),
+            "应为牌型优先级相关错误，实际：{msg}"
+        );
+
+        // 拒绝后挂起仍是 B。
+        let pending_after_reject = session
+            .pending_action
+            .clone()
+            .expect("拒绝后应保留 B 的挂起");
+        assert_eq!(pending_after_reject.player_id, "player-b");
+
+        // last_successful_play 仍是 A 的对 3 —— 状态没被破坏。
+        let last_after_reject = session
+            .last_successful_play
+            .as_ref()
+            .expect("A 的对 3 应仍是上一手");
+        assert_eq!(last_after_reject.player_id, "player-a");
+        assert_eq!(last_after_reject.cards.len(), 2);
+
+        // B 改出炸弹 5555 —— 应成功（Bomb 在 successors 中包含 Pair=id 2）。
+        let b_bomb: Vec<String> = session
+            .hands
+            .get("player-b")
+            .unwrap()
+            .iter()
+            .filter(|c| c.properties.get("点数").copied() == Some(5))
+            .map(|c| c.id.clone())
+            .collect();
+        assert_eq!(b_bomb.len(), 4);
+        RuleEngine::submit_action(
+            &runtime_rule,
+            &mut session,
+            "player-b",
+            PlayerActionInput {
+                cards: b_bomb,
+                choice: None,
+            },
+        )
+        .expect("炸弹应能压住对 3");
+
+        let last = session
+            .last_successful_play
+            .as_ref()
+            .expect("应记录 B 的炸弹出牌");
+        assert_eq!(last.player_id, "player-b");
+        assert_eq!(last.cards.len(), 4);
+        for c in &last.cards {
+            assert_eq!(c.properties.get("点数").copied(), Some(5));
+        }
+    }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -769,6 +769,13 @@ const BUILTIN_RULES: &[BuiltinRuleSpec] = &[
         description: "经典累加玩法：每人 14 张牌，轮流出牌把点数加进桌面总和；让总和超过 99 的玩家输。",
         design_file: "nine_nine.json",
     },
+    BuiltinRuleSpec {
+        id: "builtin-bigtwo-rule",
+        name: "大老二极简版",
+        player_count: 2,
+        description: "简化版大老二：单/对/三 + 炸弹，先出完赢。注意：极简版规则下，双方均无法压制当前牌型时可能进入死锁，建议尝试单张或小对子开局以保留出牌空间。",
+        design_file: "big_two.json",
+    },
 ];
 
 fn build_builtin_rules() -> Vec<PublishedRule> {


### PR DESCRIPTION
见 #83。第 3/4 款 A 路线预设规则。

## 玩法
2 人对局，每人 8 张牌（标准 52 张扑克）。出牌类型：单张 / 对子 / 三张 / 炸弹。后续出牌必须同型更大，或用炸弹通杀任意非炸弹牌型。先出完手牌者赢。

## 实现要点
- `big_two.json` 232 行：4 个 cardset（Single/Pair/Triple/Bomb）+ Bomb.successors=[Single,Pair,Triple] 实现"炸弹通杀"
- 5 个端到端单测覆盖：
  - 单张连续出完赢（happy path）
  - 对子必须更大才能压（被拒后玩家不切换）
  - 炸弹通杀三张（验证 successors 配置正确）
  - 首手不能 pass（命中引擎保护 rule_engine.rs:573-578）
  - 跨牌型必须用炸弹（无 successors + 无 cardset_comparisons 路径）
- 注册到 BUILTIN_RULES const 表

## 已知遗留 - 必读
引擎当前没有 JSON 可触达的"清桌"原语（清空 last_successful_play）。意味着：
**两人手里都没大牌时可能死锁** —— A 出对 K，B 无更大对也无炸弹只能 pass，回到 A 时 A 也压不过自己 → 双方互相 pass 直到 FLOW_STEP_LIMIT=1000 报死循环。

description 已加警告"建议尝试单张或小对子开局以保留出牌空间"。**真正修复需要后续 cleanup PR 扩引擎加 component_type**（这次按"不扩引擎"原则未做）。

Refs #83
