### PR TITLE
feat(market): add 21 点 (伪版) preset rule

### DIFF
--- a/blackjack.json
+++ b/blackjack.json
@@ -1,0 +1,141 @@
+{
+  "classes": {
+    "player": {
+      "default_properties": {},
+      "user_properties": {
+        "score": {
+          "type": "int",
+          "default": 0
+        }
+      },
+      "methods": {}
+    },
+    "card": {
+      "default_properties": {
+        "点数": {
+          "type": "enum",
+          "default": 1,
+          "config": [
+            { "id": "bj-point-1", "display": "A", "value": 1 },
+            { "id": "bj-point-2", "display": "2", "value": 2 },
+            { "id": "bj-point-3", "display": "3", "value": 3 },
+            { "id": "bj-point-4", "display": "4", "value": 4 },
+            { "id": "bj-point-5", "display": "5", "value": 5 },
+            { "id": "bj-point-6", "display": "6", "value": 6 },
+            { "id": "bj-point-7", "display": "7", "value": 7 },
+            { "id": "bj-point-8", "display": "8", "value": 8 },
+            { "id": "bj-point-9", "display": "9", "value": 9 },
+            { "id": "bj-point-10", "display": "10", "value": 10 },
+            { "id": "bj-point-11", "display": "J", "value": 11 },
+            { "id": "bj-point-12", "display": "Q", "value": 12 },
+            { "id": "bj-point-13", "display": "K", "value": 13 }
+          ]
+        },
+        "花色": {
+          "type": "enum",
+          "default": 0,
+          "config": [
+            { "id": "bj-suit-0", "display": "S", "value": 0 },
+            { "id": "bj-suit-1", "display": "H", "value": 1 },
+            { "id": "bj-suit-2", "display": "C", "value": 2 },
+            { "id": "bj-suit-3", "display": "D", "value": 3 }
+          ]
+        }
+      },
+      "user_properties": {},
+      "methods": {}
+    },
+    "table": {
+      "default_properties": {},
+      "user_properties": {
+        "p0_score": { "type": "int", "default": 0 },
+        "p1_score": { "type": "int", "default": 0 },
+        "winner_index": { "type": "int", "default": -1 }
+      },
+      "methods": {}
+    }
+  },
+  "cardsets": {
+    "1": {
+      "name": "Three",
+      "properties": {},
+      "build_flow": {
+        "1": { "type": 27, "content": { "next": "2" } },
+        "2": { "type": 7, "content": { "selection": "cards", "next": "3" } },
+        "3": { "type": 8, "content": { "value": 3, "next": "4" } },
+        "4": { "type": 14, "content": { "operator": 0, "lval": "2", "rval": "3", "next": "5" } },
+        "5": { "type": 16, "content": { "condition": "4", "next_true": "6", "next_false": "7" } },
+        "6": { "type": 28, "content": { "result": 1, "properties": {} } },
+        "7": { "type": 28, "content": { "result": 0, "properties": {} } }
+      },
+      "compare_flow": {
+        "1": { "type": 29, "content": { "cardsetA": "Three", "cardsetB": "Three", "next": "2" } },
+        "2": { "type": 30, "content": { "result": 0 } }
+      },
+      "successors": []
+    }
+  },
+  "cardset_comparisons": {},
+  "match_flow": {
+    "1": { "type": 17, "content": { "next": "2" } },
+    "2": { "type": 20, "content": { "prop_pair": [], "next": "3" }, "count": 3 },
+
+    "3": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_zero", "next": "4" } },
+    "4": { "type": 21, "content": { "timer": 30, "next": "5" } },
+    "5": { "type": 4, "content": { "component": "m_p0_score", "rvalue": "m_played_sum", "next": "6" } },
+
+    "6": { "type": 4, "content": { "component": "m_player_index", "rvalue": "v_one", "next": "7" } },
+    "7": { "type": 21, "content": { "timer": 30, "next": "8" } },
+    "8": { "type": 4, "content": { "component": "m_p1_score", "rvalue": "m_played_sum", "next": "9" } },
+
+    "9": { "type": 16, "content": { "condition": "cmp_p0_bust", "next_true": "10", "next_false": "13" } },
+    "10": { "type": 16, "content": { "condition": "cmp_p1_bust", "next_true": "11", "next_false": "12" } },
+    "11": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_neg_one", "next": "to_end" } },
+    "12": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_one", "next": "to_end" } },
+    "13": { "type": 16, "content": { "condition": "cmp_p1_bust", "next_true": "14", "next_false": "15" } },
+    "14": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_zero", "next": "to_end" } },
+    "15": { "type": 16, "content": { "condition": "cmp_p0_gt_p1", "next_true": "16", "next_false": "17" } },
+    "16": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_zero", "next": "to_end" } },
+    "17": { "type": 16, "content": { "condition": "cmp_p0_lt_p1", "next_true": "18", "next_false": "19" } },
+    "18": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_one", "next": "to_end" } },
+    "19": { "type": 4, "content": { "component": "m_winner_idx", "rvalue": "v_neg_one", "next": "to_end" } },
+
+    "to_end": { "type": 18, "content": {} },
+
+    "m_player_index": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "player_index" } },
+    "m_p0_score": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p0_score" } },
+    "m_p1_score": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "p1_score" } },
+    "m_winner_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+
+    "v_zero": { "type": 8, "content": { "value": 0 } },
+    "v_one": { "type": 8, "content": { "value": 1 } },
+    "v_two": { "type": 8, "content": { "value": 2 } },
+    "v_neg_one": { "type": 8, "content": { "value": -1 } },
+    "v_21": { "type": 8, "content": { "value": 21 } },
+
+    "m_played_card0": { "type": 5, "content": { "selection": "4", "index": "v_zero" } },
+    "m_played_card1": { "type": 5, "content": { "selection": "4", "index": "v_one" } },
+    "m_played_card2": { "type": 5, "content": { "selection": "4", "index": "v_two" } },
+    "m_played_point0": { "type": 6, "content": { "operator": 1, "ident": "m_played_card0", "property": "点数" } },
+    "m_played_point1": { "type": 6, "content": { "operator": 1, "ident": "m_played_card1", "property": "点数" } },
+    "m_played_point2": { "type": 6, "content": { "operator": 1, "ident": "m_played_card2", "property": "点数" } },
+    "m_played_partial": { "type": 10, "content": { "operator": 0, "lval": "m_played_point0", "rval": "m_played_point1" } },
+    "m_played_sum": { "type": 10, "content": { "operator": 0, "lval": "m_played_partial", "rval": "m_played_point2" } },
+
+    "cmp_p0_bust": { "type": 14, "content": { "operator": 1, "lval": "m_p0_score", "rval": "v_21" } },
+    "cmp_p1_bust": { "type": 14, "content": { "operator": 1, "lval": "m_p1_score", "rval": "v_21" } },
+    "cmp_p0_gt_p1": { "type": 14, "content": { "operator": 1, "lval": "m_p0_score", "rval": "m_p1_score" } },
+    "cmp_p0_lt_p1": { "type": 14, "content": { "operator": 2, "lval": "m_p0_score", "rval": "m_p1_score" } }
+  },
+  "end_flow": {
+    "1": { "type": 23, "content": { "next": "2" } },
+    "2": { "type": 16, "content": { "condition": "cmp_settle_eq_winner", "next_true": "3", "next_false": "4" } },
+    "3": { "type": 24, "content": { "result": 1 } },
+    "4": { "type": 24, "content": { "result": 0 } },
+
+    "e_settle_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "settlement_index" } },
+    "e_winner_idx": { "type": 6, "content": { "operator": 0, "ident": "table_0", "property": "winner_index" } },
+
+    "cmp_settle_eq_winner": { "type": 14, "content": { "operator": 0, "lval": "e_settle_idx", "rval": "e_winner_idx" } }
+  }
+}

--- a/src/domain/rule_engine.rs
+++ b/src/domain/rule_engine.rs
@@ -2650,6 +2650,44 @@ fn shuffle_deck(session: &mut GameSession) {
 mod tests {
     use super::*;
 
+    /// 通用工具：清空 session 中所有手牌与牌堆，按 mapping 依据“点数”精确补回
+    /// 给每个 player；剩余牌回到 session.deck，并刷新 player.手牌数。
+    /// 测试需要确定性的手牌组合，不能依赖自然发牌（HashMap 迭代顺序不定）。
+    fn force_hands(session: &mut GameSession, mapping: &[(&str, &[i64])]) {
+        let mut pool: Vec<GameCard> = Vec::new();
+        pool.append(&mut session.deck);
+        for hand in session.hands.values_mut() {
+            pool.append(hand);
+        }
+        pool.append(&mut session.discard_pile);
+
+        fn take_by_point(pool: &mut Vec<GameCard>, point: i64) -> GameCard {
+            let pos = pool
+                .iter()
+                .position(|card| card.properties.get("点数").copied().unwrap_or_default() == point)
+                .unwrap_or_else(|| panic!("pool exhausted for point {point}"));
+            pool.remove(pos)
+        }
+
+        for (player_id, points) in mapping {
+            let hand: Vec<GameCard> = points
+                .iter()
+                .map(|p| take_by_point(&mut pool, *p))
+                .collect();
+            session.hands.insert((*player_id).to_string(), hand);
+        }
+        session.deck = pool;
+
+        for player in &mut session.players {
+            let count = session
+                .hands
+                .get(&player.id)
+                .map(Vec::len)
+                .unwrap_or_default() as i64;
+            player.properties.insert("手牌数".to_string(), count);
+        }
+    }
+
     fn load_tiny_demo_rule() -> RuntimeRule {
         let content = std::fs::read_to_string(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test2.json"),
@@ -3018,42 +3056,7 @@ mod tests {
     /// 剩下的丢回 session.deck，并刷新 player.手牌数。
     /// 测试需要确定性的手牌组合，不能依赖自然发牌（HashMap 迭代顺序不定）。
     fn force_bigtwo_hands(session: &mut GameSession, a_points: &[i64], b_points: &[i64]) {
-        let mut pool: Vec<GameCard> = Vec::new();
-        pool.append(&mut session.deck);
-        for hand in session.hands.values_mut() {
-            pool.append(hand);
-        }
-        pool.append(&mut session.discard_pile);
-
-        fn take_by_point(pool: &mut Vec<GameCard>, point: i64) -> GameCard {
-            let pos = pool
-                .iter()
-                .position(|card| card.properties.get("点数").copied().unwrap_or_default() == point)
-                .unwrap_or_else(|| panic!("pool exhausted for point {point}"));
-            pool.remove(pos)
-        }
-
-        let a_hand: Vec<GameCard> = a_points
-            .iter()
-            .map(|p| take_by_point(&mut pool, *p))
-            .collect();
-        let b_hand: Vec<GameCard> = b_points
-            .iter()
-            .map(|p| take_by_point(&mut pool, *p))
-            .collect();
-
-        session.hands.insert("player-a".to_string(), a_hand);
-        session.hands.insert("player-b".to_string(), b_hand);
-        session.deck = pool;
-
-        for player in &mut session.players {
-            let count = session
-                .hands
-                .get(&player.id)
-                .map(Vec::len)
-                .unwrap_or_default() as i64;
-            player.properties.insert("手牌数".to_string(), count);
-        }
+        force_hands(session, &[("player-a", a_points), ("player-b", b_points)]);
     }
 
     fn find_hand_card_by_point(
@@ -3524,5 +3527,204 @@ mod tests {
         for c in &last.cards {
             assert_eq!(c.properties.get("点数").copied(), Some(5));
         }
+    }
+
+    fn load_blackjack_rule() -> RuntimeRule {
+        let content = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("blackjack.json"),
+        )
+        .expect("blackjack.json should exist");
+        let design: ExportedRuleDesign =
+            serde_json::from_str(&content).expect("blackjack.json should be valid rule json");
+
+        RuleEngine::parse(
+            "21 点（伪版）".to_string(),
+            2,
+            "伪版 21 点：每人 3 张明牌，直接累加点数".to_string(),
+            design,
+        )
+        .expect("blackjack rule should compile")
+    }
+
+    /// 21 点强行注入手牌；与 force_bigtwo_hands 同构，但目标长度固定为 3。
+    fn force_blackjack_hands(session: &mut GameSession, a_points: &[i64], b_points: &[i64]) {
+        force_hands(session, &[("player-a", a_points), ("player-b", b_points)]);
+    }
+
+    /// 每个玩家把强行注入的 3 张手牌一次性全部亮出（type 21 出牌动作 → 把 3 张
+    /// 推进 last_action_cards，match_flow 的 m_played_sum 据此累加并写入 table 分数）。
+    fn play_all_three(runtime_rule: &RuntimeRule, session: &mut GameSession, player_id: &str) {
+        let pending = session
+            .pending_action
+            .clone()
+            .unwrap_or_else(|| panic!("{player_id} 应有挂起的出牌动作"));
+        assert_eq!(pending.component_type, 21);
+        assert_eq!(pending.player_id, player_id);
+
+        let card_ids: Vec<String> = session
+            .hands
+            .get(player_id)
+            .map(|cards| cards.iter().map(|card| card.id.clone()).collect())
+            .unwrap_or_default();
+        assert_eq!(card_ids.len(), 3, "{player_id} 必须正好持有 3 张牌");
+
+        RuleEngine::submit_action(
+            runtime_rule,
+            session,
+            player_id,
+            PlayerActionInput {
+                cards: card_ids,
+                choice: None,
+            },
+        )
+        .unwrap_or_else(|err| panic!("{player_id} 亮出 3 张失败：{err:?}"));
+    }
+
+    #[test]
+    fn simulate_blackjack_smaller_score_wins_when_neither_bust() {
+        // A = 5+7+8 = 20，B = 3+4+9 = 16，双方都没爆 → A 更接近 21 应赢。
+        let runtime_rule = load_blackjack_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bj-1".to_string(), &runtime_rule, player_ids)
+                .expect("blackjack session should start");
+
+        // 开局应直接发完 3 张并挂起 player-a 的出牌动作。
+        assert_eq!(session.hands.get("player-a").map(Vec::len), Some(3));
+        assert_eq!(session.hands.get("player-b").map(Vec::len), Some(3));
+
+        force_blackjack_hands(&mut session, &[5, 7, 8], &[3, 4, 9]);
+
+        play_all_three(&runtime_rule, &mut session, "player-a");
+        play_all_three(&runtime_rule, &mut session, "player-b");
+
+        assert_eq!(session.status, "finished", "双方亮牌后应直接进入结算");
+        assert!(session.pending_action.is_none());
+
+        assert_eq!(
+            session.table.get("p0_score").copied(),
+            Some(20),
+            "p0_score 应为 20"
+        );
+        assert_eq!(
+            session.table.get("p1_score").copied(),
+            Some(16),
+            "p1_score 应为 16"
+        );
+        assert_eq!(
+            session.table.get("winner_index").copied(),
+            Some(0),
+            "A 更接近 21 应赢"
+        );
+        assert_eq!(session.settlement_results.get("player-a"), Some(&1));
+        assert_eq!(session.settlement_results.get("player-b"), Some(&0));
+    }
+
+    #[test]
+    fn simulate_blackjack_only_non_bust_wins() {
+        // A = 10+10+5 = 25（爆），B = 3+4+5 = 12（不爆）→ B 应赢。
+        let runtime_rule = load_blackjack_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bj-2".to_string(), &runtime_rule, player_ids)
+                .expect("blackjack session should start");
+
+        force_blackjack_hands(&mut session, &[10, 10, 5], &[3, 4, 5]);
+
+        play_all_three(&runtime_rule, &mut session, "player-a");
+        play_all_three(&runtime_rule, &mut session, "player-b");
+
+        assert_eq!(session.status, "finished");
+        assert!(session.pending_action.is_none());
+
+        assert_eq!(
+            session.table.get("p0_score").copied(),
+            Some(25),
+            "p0_score 应为 25（爆牌）"
+        );
+        assert_eq!(
+            session.table.get("p1_score").copied(),
+            Some(12),
+            "p1_score 应为 12"
+        );
+        assert_eq!(
+            session.table.get("winner_index").copied(),
+            Some(1),
+            "B 没爆 A 爆，B 应赢"
+        );
+        assert_eq!(session.settlement_results.get("player-a"), Some(&0));
+        assert_eq!(session.settlement_results.get("player-b"), Some(&1));
+    }
+
+    #[test]
+    fn simulate_blackjack_both_bust_no_winner() {
+        // A = 10+10+5 = 25（爆），B = 13+13+13 = 39（爆）→ 双方都爆判和。
+        let runtime_rule = load_blackjack_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bj-3".to_string(), &runtime_rule, player_ids)
+                .expect("blackjack session should start");
+
+        force_blackjack_hands(&mut session, &[10, 10, 5], &[13, 13, 13]);
+
+        play_all_three(&runtime_rule, &mut session, "player-a");
+        play_all_three(&runtime_rule, &mut session, "player-b");
+
+        assert_eq!(session.status, "finished", "双方亮牌后应进入结算");
+        assert!(session.pending_action.is_none());
+
+        assert_eq!(
+            session.table.get("p0_score").copied(),
+            Some(25),
+            "p0_score 应为 25（爆牌）"
+        );
+        assert_eq!(
+            session.table.get("p1_score").copied(),
+            Some(39),
+            "p1_score 应为 39（爆牌）"
+        );
+        assert_eq!(
+            session.table.get("winner_index").copied(),
+            Some(-1),
+            "双方都爆 winner_index 应为 -1"
+        );
+        assert_eq!(session.settlement_results.get("player-a"), Some(&0));
+        assert_eq!(session.settlement_results.get("player-b"), Some(&0));
+    }
+
+    #[test]
+    fn simulate_blackjack_tie_score_no_winner() {
+        // A = 5+5+5 = 15，B = 3+6+6 = 15，两边都没爆且同分 → 平局判和。
+        let runtime_rule = load_blackjack_rule();
+        let player_ids = vec!["player-a".to_string(), "player-b".to_string()];
+        let mut session =
+            RuleEngine::start_session("room-bj-4".to_string(), &runtime_rule, player_ids)
+                .expect("blackjack session should start");
+
+        force_blackjack_hands(&mut session, &[5, 5, 5], &[3, 6, 6]);
+
+        play_all_three(&runtime_rule, &mut session, "player-a");
+        play_all_three(&runtime_rule, &mut session, "player-b");
+
+        assert_eq!(session.status, "finished", "双方亮牌后应进入结算");
+        assert!(session.pending_action.is_none());
+
+        assert_eq!(
+            session.table.get("p0_score").copied(),
+            Some(15),
+            "p0_score 应为 15"
+        );
+        assert_eq!(
+            session.table.get("p1_score").copied(),
+            Some(15),
+            "p1_score 应为 15"
+        );
+        assert_eq!(
+            session.table.get("winner_index").copied(),
+            Some(-1),
+            "同分时 winner_index 应为 -1"
+        );
+        assert_eq!(session.settlement_results.get("player-a"), Some(&0));
+        assert_eq!(session.settlement_results.get("player-b"), Some(&0));
     }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -776,6 +776,13 @@ const BUILTIN_RULES: &[BuiltinRuleSpec] = &[
         description: "简化版大老二：单/对/三 + 炸弹，先出完赢。注意：极简版规则下，双方均无法压制当前牌型时可能进入死锁，建议尝试单张或小对子开局以保留出牌空间。",
         design_file: "big_two.json",
     },
+    BuiltinRuleSpec {
+        id: "builtin-blackjack-rule",
+        name: "21 点（伪版）",
+        player_count: 2,
+        description: "伪版 21 点：无要牌/停牌阶段，每方一次性提交 3 张明牌后直接比较结果。A=1，J/Q/K 按字面 11/12/13 算；谁的总和最接近 21 但不超过谁赢，双方均爆或平局判和。",
+        design_file: "blackjack.json",
+    },
 ];
 
 fn build_builtin_rules() -> Vec<PublishedRule> {


### PR DESCRIPTION
见 #83。第 4/4 款 A 路线预设规则。

## 玩法
2 人对局，每人发 3 张明牌，把点数累加（A=1, J/Q/K 按字面 11/12/13 算），谁更接近 21 但不超过谁赢；都超过算平，相等也算平。**伪版：无要牌/停牌阶段，每方一次性提交 3 张明牌后直接比较结果**。

## 实现要点
- `blackjack.json` 141 行：match_flow 算两人 sum 写 table，end_flow 按 winner_index 派 result
- 4 个端到端单测：A 大且不爆赢、仅 A 爆 B 赢、双方都爆平、sum 相等平
- 抽通用测试 helper `force_hands(session, mapping)`，big_two 和 blackjack 共用
- 注册到 BUILTIN_RULES 常量表（1 行追加）

## 引擎缺陷暴露
做这款规则发现：**DSL 无法直接读 player.手牌**。eval_value 里 `EvalValue::Player` 的属性访问 (rule_engine.rs:1537+) 只查 `player.properties`，不查 hands。

绕开方式：要求玩家先把全部手牌"出牌"（作为单一 cardset），引擎通过 `last_action_cards` 拿到牌，再算 sum 写 table。这导致 UX 看起来不像传统 21 点——更像"自动 stand"。

真正的 hit/stand 21 点需要扩引擎，建议作为后续 RFC（与大老二的"清桌"原语合并立项）。

Refs #83
