### PR TITLE
fix(market): add image upload endpoint for reviews

### DIFF
--- a/src/interface/market.rs
+++ b/src/interface/market.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Multipart, Path, Query, State},
 };
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
@@ -12,7 +12,8 @@ use crate::error::AppError;
 use crate::infrastructure::user::UserRepository;
 use crate::interface::auth::TokenClaims;
 use crate::interface::rule::{ApiResponse, RulePersistence};
-use crate::state::{RoomStore, RuleStore};
+use crate::interface::user::extension_for_mime;
+use crate::state::{RoomStore, RuleStore, UploadDir};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MarketDeveloper {
@@ -529,6 +530,13 @@ pub async fn create_review(
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
+    if let Some(url) = image_url.as_ref()
+        && url.len() > 512
+    {
+        return Err(AppError::InvalidInput(
+            "图片地址过长，请先调用图片上传接口拿到短 URL".to_string(),
+        ));
+    }
 
     sqlx::query(
         r#"
@@ -575,4 +583,61 @@ fn now_millis() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+const REVIEW_IMAGE_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadedImageResponse {
+    pub image_url: String,
+}
+
+/// 接收 multipart 文件，落盘到 uploads/review-images/，返回短 URL。
+/// 前端用这个 URL 再发给 POST /reviews 的 imageUrl 字段。
+#[tracing::instrument(skip(multipart, upload_dir))]
+pub async fn upload_review_image(
+    TokenClaims { user_id: _, .. }: TokenClaims,
+    State(upload_dir): State<UploadDir>,
+    mut multipart: Multipart,
+) -> Result<Json<ApiResponse<UploadedImageResponse>>, AppError> {
+    let mut field = multipart
+        .next_field()
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("解析上传失败：{e}")))?
+        .ok_or_else(|| AppError::InvalidInput("缺少上传文件".to_string()))?;
+
+    let content_type = field.content_type().map(str::to_string).unwrap_or_default();
+    let extension = extension_for_mime(&content_type)
+        .ok_or_else(|| AppError::InvalidInput("仅支持 png / jpeg / webp 格式".to_string()))?;
+
+    let mut bytes = Vec::with_capacity(16 * 1024);
+    while let Some(chunk) = field
+        .chunk()
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("读取上传内容失败：{e}")))?
+    {
+        if bytes.len() + chunk.len() > REVIEW_IMAGE_MAX_BYTES {
+            return Err(AppError::InvalidInput("评论图片不能超过 2MB".to_string()));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if bytes.is_empty() {
+        return Err(AppError::InvalidInput("上传文件为空".to_string()));
+    }
+
+    let dir = upload_dir.0.join("review-images");
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("创建上传目录失败：{e}")))?;
+
+    let filename = format!("{}.{extension}", uuid::Uuid::new_v4());
+    let path = dir.join(&filename);
+    tokio::fs::write(&path, &bytes)
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("写入文件失败：{e}")))?;
+
+    Ok(Json(ApiResponse::success(UploadedImageResponse {
+        image_url: format!("/static/review-images/{filename}"),
+    })))
 }

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -534,7 +534,7 @@ pub async fn update_email(
 
 const AVATAR_MAX_BYTES: usize = 2 * 1024 * 1024;
 
-fn extension_for_mime(mime: &str) -> Option<&'static str> {
+pub fn extension_for_mime(mime: &str) -> Option<&'static str> {
     match mime {
         "image/png" => Some("png"),
         "image/jpeg" | "image/jpg" => Some("jpg"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,10 @@ async fn main() {
             post(market::create_review),
         )
         .route(
+            "/api/rules/reviews/images",
+            post(market::upload_review_image),
+        )
+        .route(
             "/api/rules/published/{rule_id}/fork",
             post(rule::fork_published_rule),
         )


### PR DESCRIPTION
## Bug
规则市场详情页提交「带图片的评论」一定失败，提示「评论提交失败」。

## 真因
- DB `rule_reviews.image_url VARCHAR(512)`
- FE 把图片读成 `data:image/...;base64,...` dataURL 直接塞进 JSON 的 `imageUrl` 字段 → 任何真实照片 base64 后远超 512 字节
- DB 报 `value too long for type character varying(512)`，BE 返失败 → 用户看到「评论提交失败」

curl 复现：
```
=== dataURL 5KB ===
{"success":false,"message":"value too long for type character varying(512)"}
```

## 修复
新增 `POST /api/rules/reviews/images`：
- multipart 上传，仅接受 png/jpeg/webp，≤2MB
- 落盘到 `uploads/review-images/<uuid>.<ext>`
- 返回短 URL `/static/review-images/<file>`
- 复用 user.rs 的 `extension_for_mime`（提升为 pub）

`create_review` 端也加防御：`imageUrl` 长度 >512 直接返 InvalidInput，避免再次 DB 报错。

配套 FE PR 改为：先 multipart 上传图片拿短 URL，再以该 URL 作为 `imageUrl` 调 `POST /reviews`。

## 测试
- 全部 CI 通过（fmt / clippy --all-features -D warnings / cargo test / autocorrect）
- 现有 30 个 fork+market 相关测试都过

Refs #83
