### PR TITLE
fix(user): include role in UserDto so frontend can gate admin UI

### DIFF
--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -40,6 +40,7 @@ pub struct UserDto {
     pub username: String,
     pub email: String,
     pub avatar: String,
+    pub role: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }
@@ -51,6 +52,7 @@ impl UserDto {
             username: user.name,
             email: user.email,
             avatar: user.avatar,
+            role: user.role,
             token: None,
         }
     }


### PR DESCRIPTION
Phase 1 加了 User.role，Phase 2A FE 也把 isAdmin 接进了 userStore，但 UserDto::from_user 漏掉 role 字段，导致 /current 和 register/login response 永远不带 role，FE 永远算不出 isAdmin=true，admin 用户看不到「规则审核」入口。补 2 行。