### PR TITLE
test: boost backend coverage

### DIFF
--- a/tests/infrastructure_coverage_tests.rs
+++ b/tests/infrastructure_coverage_tests.rs
@@ -1,0 +1,192 @@
+#![allow(dead_code)]
+
+mod error {
+    pub use wildcard_backend::error::*;
+}
+
+mod domain {
+    pub mod user {
+        pub use wildcard_backend::domain::user::*;
+    }
+}
+
+mod infrastructure {
+    pub mod email {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/infrastructure/email.rs"
+        ));
+
+        #[cfg(test)]
+        mod coverage {
+            use super::*;
+            use std::sync::{Mutex, OnceLock};
+
+            fn env_lock() -> &'static Mutex<()> {
+                static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+                LOCK.get_or_init(|| Mutex::new(()))
+            }
+
+            unsafe fn set_env(key: &str, value: &str) {
+                unsafe { std::env::set_var(key, value) };
+            }
+
+            unsafe fn remove_env(key: &str) {
+                unsafe { std::env::remove_var(key) };
+            }
+
+            fn clear_smtp_env() {
+                for key in [
+                    "SMTP_HOST",
+                    "SMTP_PORT",
+                    "SMTP_USER",
+                    "SMTP_PASS",
+                    "SMTP_FROM",
+                ] {
+                    unsafe { remove_env(key) };
+                }
+            }
+
+            #[test]
+            fn smtp_config_from_env_covers_missing_invalid_and_present_values() {
+                let _guard = env_lock()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                clear_smtp_env();
+                assert!(SmtpConfig::from_env().is_none());
+
+                unsafe {
+                    set_env("SMTP_HOST", "smtp.example.com");
+                    set_env("SMTP_PORT", "not-a-port");
+                    set_env("SMTP_USER", "user");
+                    set_env("SMTP_PASS", "pass");
+                    set_env("SMTP_FROM", "noreply@example.com");
+                }
+                assert!(SmtpConfig::from_env().is_none());
+
+                unsafe { set_env("SMTP_PORT", "2525") };
+                let cfg = SmtpConfig::from_env().unwrap();
+                assert_eq!(cfg.host, "smtp.example.com");
+                assert_eq!(cfg.port, 2525);
+                assert_eq!(cfg.from, "noreply@example.com");
+                clear_smtp_env();
+            }
+
+            #[test]
+            fn email_sender_from_env_and_build_cover_fallbacks() {
+                let _guard = env_lock()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                clear_smtp_env();
+                assert!(!EmailSender::from_env().is_configured());
+
+                let configured = EmailSender::build(SmtpConfig {
+                    host: "localhost".to_string(),
+                    port: 2525,
+                    user: "user".to_string(),
+                    pass: "pass".to_string(),
+                    from: "not-an-email".to_string(),
+                })
+                .unwrap();
+                assert!(configured.is_configured());
+
+                let runtime = tokio::runtime::Runtime::new().unwrap();
+                let err = runtime
+                    .block_on(configured.send_verification_code("user@example.com", "123456"))
+                    .unwrap_err();
+                assert!(matches!(err, EmailSendError::InvalidAddress(_)));
+            }
+
+            #[tokio::test]
+            async fn unconfigured_sender_send_and_error_display_paths_are_covered() {
+                let sender = EmailSender { inner: None };
+                let err = sender
+                    .send_verification_code("user@example.com", "123456")
+                    .await
+                    .unwrap_err();
+                assert!(matches!(err, EmailSendError::NotConfigured));
+                assert_eq!(err.to_string(), "SMTP not configured");
+                assert!(
+                    EmailSendError::InvalidAddress("bad".to_string())
+                        .to_string()
+                        .contains("bad")
+                );
+                assert!(
+                    EmailSendError::Build("broken".to_string())
+                        .to_string()
+                        .contains("broken")
+                );
+                assert!(
+                    EmailSendError::Smtp("down".to_string())
+                        .to_string()
+                        .contains("down")
+                );
+                assert!(build_verification_body("654321").contains("654321"));
+            }
+        }
+    }
+
+    pub mod user {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/infrastructure/user.rs"
+        ));
+
+        #[cfg(test)]
+        mod coverage {
+            use super::*;
+            use crate::domain::user::{User, UserId};
+            use sqlx::postgres::PgPoolOptions;
+            use uuid::Uuid;
+
+            fn lazy_repo() -> UserRepository {
+                UserRepository {
+                    pool: PgPoolOptions::new()
+                        .acquire_timeout(std::time::Duration::from_millis(50))
+                        .connect_lazy("postgres://user:password@127.0.0.1:1/wildcard_test")
+                        .unwrap(),
+                }
+            }
+
+            fn user() -> User {
+                User {
+                    id: UserId(Uuid::new_v4()),
+                    name: "coverage-user".to_string(),
+                    email: "coverage@example.com".to_string(),
+                    password: "secret".to_string(),
+                    avatar: String::new(),
+                    role: "user".to_string(),
+                }
+            }
+
+            #[tokio::test]
+            async fn database_methods_cover_query_construction_and_error_mapping() {
+                let repo = lazy_repo();
+                let user = user();
+                let user_id = user.id.clone();
+
+                assert!(repo.register(user).await.is_err());
+                assert!(repo.find_by_name("missing").await.is_err());
+                assert!(repo.find_by_email("missing@example.com").await.is_err());
+                assert!(repo.find_by_id(&user_id).await.is_err());
+                assert!(repo.update_username(&user_id, "new-name").await.is_err());
+                assert!(
+                    repo.update_email(&user_id, "new@example.com")
+                        .await
+                        .is_err()
+                );
+                assert!(repo.update_password(&user_id, "new-secret").await.is_err());
+                assert!(repo.update_avatar(&user_id, "/avatar.png").await.is_err());
+            }
+
+            #[test]
+            fn password_hashing_covers_unique_hashes_and_malformed_inputs() {
+                let first = UserRepository::password_hash("secret").unwrap();
+                let second = UserRepository::password_hash("secret").unwrap();
+                assert_ne!(first, second);
+                assert!(UserRepository::check_password("secret", &first));
+                assert!(!UserRepository::check_password("secret", "$argon2id$bad"));
+            }
+        }
+    }
+}

--- a/tests/market_interface_coverage_tests.rs
+++ b/tests/market_interface_coverage_tests.rs
@@ -1,0 +1,459 @@
+#![allow(dead_code)]
+
+mod error {
+    pub use wildcard_backend::error::*;
+}
+
+mod domain {
+    pub mod room {
+        pub use wildcard_backend::domain::room::*;
+    }
+    pub mod rule_engine {
+        pub use wildcard_backend::domain::rule_engine::*;
+    }
+    pub mod user {
+        pub use wildcard_backend::domain::user::*;
+    }
+}
+
+mod infrastructure {
+    pub mod user {
+        use crate::{
+            domain::user::{User, UserId},
+            error::AppError,
+        };
+        use sqlx::PgPool;
+
+        #[derive(Debug)]
+        pub struct UserRepository {
+            pub pool: PgPool,
+        }
+
+        impl UserRepository {
+            pub async fn find_by_id(&self, _user_id: &UserId) -> Result<Option<User>, AppError> {
+                Ok(None)
+            }
+        }
+    }
+}
+
+mod interface {
+    pub mod auth {
+        use crate::domain::user::UserId;
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Debug, Serialize, Deserialize)]
+        pub struct TokenClaims {
+            #[serde(rename = "sub")]
+            pub user_id: UserId,
+            pub iat: usize,
+            pub exp: usize,
+        }
+    }
+
+    pub mod user {
+        pub fn extension_for_mime(mime: &str) -> Option<&'static str> {
+            match mime {
+                "image/png" => Some("png"),
+                "image/jpeg" | "image/jpg" => Some("jpg"),
+                "image/webp" => Some("webp"),
+                _ => None,
+            }
+        }
+    }
+
+    pub mod rule {
+        use crate::domain::rule_engine::{ExportedRuleDesign, RuntimeRule};
+        use serde::Serialize;
+        use sqlx::PgPool;
+        use std::collections::HashMap;
+
+        #[derive(Debug, Serialize)]
+        pub struct ApiResponse<T> {
+            pub success: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub data: Option<T>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub message: Option<String>,
+        }
+
+        impl<T> ApiResponse<T> {
+            pub(crate) fn success(data: T) -> Self {
+                Self {
+                    success: true,
+                    data: Some(data),
+                    message: None,
+                }
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        pub struct RulePersistence {
+            pub pool: PgPool,
+        }
+
+        #[derive(Debug, Clone)]
+        pub struct PublishedRule {
+            pub id: String,
+            pub owner_id: String,
+            pub name: String,
+            pub player_count: u8,
+            pub description: String,
+            pub version: u32,
+            pub design: ExportedRuleDesign,
+            pub runtime: RuntimeRule,
+            pub created_at: i64,
+            pub updated_at: i64,
+            pub introduction: String,
+            pub cover_url: String,
+            pub screenshot_urls: Vec<String>,
+        }
+
+        #[derive(Debug, Default)]
+        pub struct RuleRepository {
+            pub published: HashMap<String, PublishedRule>,
+        }
+    }
+
+    pub mod room {
+        use crate::{
+            domain::{room::Room, rule_engine::GameSession},
+            state::RoomStore,
+        };
+        use std::{collections::HashMap, sync::Arc};
+        use tokio::sync::RwLock;
+
+        #[derive(Debug, Default)]
+        pub struct RoomRepository {
+            pub rooms: HashMap<String, Room>,
+            pub player_rooms: HashMap<String, String>,
+            pub sessions: HashMap<String, GameSession>,
+        }
+
+        pub fn build_room_store() -> RoomStore {
+            Arc::new(RwLock::new(RoomRepository::default()))
+        }
+    }
+
+    pub mod market {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/interface/market.rs"
+        ));
+
+        #[cfg(test)]
+        mod endpoint_coverage {
+            use super::*;
+            use axum::{
+                Router,
+                body::{Body, to_bytes},
+                http::{Request, StatusCode, header},
+                routing::post,
+            };
+            use sqlx::postgres::PgPoolOptions;
+            use tokio::sync::RwLock;
+            use tower::ServiceExt;
+            use uuid::Uuid;
+
+            use crate::{
+                domain::{
+                    rule_engine::{ExportedRuleDesign, RuleEngine},
+                    user::UserId,
+                },
+                infrastructure::user::UserRepository,
+                interface::{
+                    auth::TokenClaims,
+                    rule::{PublishedRule, RulePersistence, RuleRepository},
+                },
+                state::{RuleStore, UploadDir},
+            };
+
+            fn lazy_pool() -> sqlx::PgPool {
+                PgPoolOptions::new()
+                    .acquire_timeout(std::time::Duration::from_millis(50))
+                    .connect_lazy("postgres://user:password@127.0.0.1:1/wildcard_test")
+                    .unwrap()
+            }
+
+            fn claims() -> TokenClaims {
+                TokenClaims {
+                    user_id: UserId(Uuid::new_v4()),
+                    iat: 0,
+                    exp: usize::MAX,
+                }
+            }
+
+            fn valid_design() -> ExportedRuleDesign {
+                let content = std::fs::read_to_string(
+                    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("war.json"),
+                )
+                .unwrap();
+                serde_json::from_str(&content).unwrap()
+            }
+
+            fn published_rule(
+                id: &str,
+                owner_id: &str,
+                name: &str,
+                created_at: i64,
+            ) -> PublishedRule {
+                let design = valid_design();
+                let runtime =
+                    RuleEngine::parse(name.to_string(), 2, "desc".to_string(), design.clone())
+                        .unwrap();
+                PublishedRule {
+                    id: id.to_string(),
+                    owner_id: owner_id.to_string(),
+                    name: name.to_string(),
+                    player_count: 2,
+                    description: format!("{name} description"),
+                    version: 1,
+                    design,
+                    runtime,
+                    created_at,
+                    updated_at: created_at,
+                    introduction: format!("{name} intro"),
+                    cover_url: format!("/static/rule-images/{id}.png"),
+                    screenshot_urls: vec![format!("/static/rule-images/{id}-1.png")],
+                }
+            }
+
+            fn store_with(rules: Vec<PublishedRule>) -> RuleStore {
+                Arc::new(RwLock::new(RuleRepository {
+                    published: rules
+                        .into_iter()
+                        .map(|rule| (rule.id.clone(), rule))
+                        .collect(),
+                }))
+            }
+
+            fn multipart_body(boundary: &str, content_type: &str, bytes: &[u8]) -> Vec<u8> {
+                let mut body = Vec::new();
+                body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+                body.extend_from_slice(
+                    b"Content-Disposition: form-data; name=\"file\"; filename=\"review.png\"\r\n",
+                );
+                body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+                body.extend_from_slice(bytes);
+                body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+                body
+            }
+
+            #[tokio::test]
+            async fn list_detail_and_developer_paths_cover_filters_and_db_fallbacks() {
+                let pool = lazy_pool();
+                let user_repo = Arc::new(UserRepository { pool: pool.clone() });
+                let persistence = RulePersistence { pool };
+                let store = store_with(vec![
+                    published_rule("builtin-alpha", "builtin-owner", "Alpha", 10),
+                    published_rule("builtin-beta", "builtin-owner", "Beta", 30),
+                    published_rule("builtin-other", "other-owner", "Other", 20),
+                ]);
+
+                let Json(all) = list_published_rules(
+                    State(store.clone()),
+                    State(user_repo.clone()),
+                    State(persistence.clone()),
+                    Query(RuleQueryParams {
+                        keyword: None,
+                        rule_type: None,
+                    }),
+                )
+                .await
+                .unwrap();
+                let all = all.data.unwrap();
+                assert_eq!(
+                    all.iter().map(|rule| rule.id.as_str()).collect::<Vec<_>>(),
+                    vec!["builtin-beta", "builtin-other", "builtin-alpha"]
+                );
+                assert_eq!(all[0].developer.name, "WildCard 内置");
+                assert_eq!(all[0].rating, 0.0);
+
+                let Json(filtered) = list_published_rules(
+                    State(store.clone()),
+                    State(user_repo.clone()),
+                    State(persistence.clone()),
+                    Query(RuleQueryParams {
+                        keyword: Some("alp".to_string()),
+                        rule_type: Some(DEFAULT_RULE_TYPE.to_string()),
+                    }),
+                )
+                .await
+                .unwrap();
+                assert_eq!(filtered.data.unwrap()[0].id, "builtin-alpha");
+
+                let Json(detail) = get_published_rule_detail(
+                    State(store.clone()),
+                    State(user_repo.clone()),
+                    State(persistence.clone()),
+                    Path("builtin-alpha".to_string()),
+                )
+                .await
+                .unwrap();
+                let detail = detail.data.unwrap();
+                assert_eq!(detail.summary.id, "builtin-alpha");
+                assert_eq!(detail.introduction, "Alpha intro");
+                assert_eq!(detail.screenshots.len(), 1);
+                assert!(detail.reviews.is_empty());
+
+                let Json(developer_rules) = list_developer_rules(
+                    State(store),
+                    State(user_repo),
+                    State(persistence),
+                    Path("builtin-owner".to_string()),
+                    Query(RuleQueryParams {
+                        keyword: Some("desc".to_string()),
+                        rule_type: None,
+                    }),
+                )
+                .await
+                .unwrap();
+                assert_eq!(developer_rules.data.unwrap().len(), 2);
+            }
+
+            #[tokio::test]
+            async fn review_validation_and_upload_image_paths_cover_new_market_features() {
+                let pool = lazy_pool();
+                let user_repo = Arc::new(UserRepository { pool: pool.clone() });
+                let persistence = RulePersistence { pool };
+                let store = store_with(vec![published_rule(
+                    "builtin-alpha",
+                    "builtin-owner",
+                    "Alpha",
+                    10,
+                )]);
+
+                let invalid_rating = create_review(
+                    claims(),
+                    State(user_repo.clone()),
+                    State(persistence.clone()),
+                    State(store.clone()),
+                    Path("builtin-alpha".to_string()),
+                    Json(CreateReviewRequest {
+                        rating: 6,
+                        content: "bad".to_string(),
+                        image_url: None,
+                    }),
+                )
+                .await
+                .unwrap_err();
+                assert!(matches!(invalid_rating, AppError::InvalidInput(_)));
+
+                let missing_rule = create_review(
+                    claims(),
+                    State(user_repo.clone()),
+                    State(persistence.clone()),
+                    State(store.clone()),
+                    Path("missing".to_string()),
+                    Json(CreateReviewRequest {
+                        rating: 5,
+                        content: "ok".to_string(),
+                        image_url: None,
+                    }),
+                )
+                .await
+                .unwrap_err();
+                assert!(matches!(missing_rule, AppError::NotFound));
+
+                let long_image = create_review(
+                    claims(),
+                    State(user_repo),
+                    State(persistence),
+                    State(store),
+                    Path("builtin-alpha".to_string()),
+                    Json(CreateReviewRequest {
+                        rating: 5,
+                        content: "ok".to_string(),
+                        image_url: Some(format!("/{}", "x".repeat(600))),
+                    }),
+                )
+                .await
+                .unwrap_err();
+                assert!(
+                    matches!(long_image, AppError::InvalidInput(message) if message.contains("图片地址"))
+                );
+
+                let upload_root =
+                    std::env::temp_dir().join(format!("wildcard-review-upload-{}", Uuid::new_v4()));
+                let upload_dir = UploadDir::from_path(upload_root.clone());
+                let app = Router::new()
+                    .route(
+                        "/upload",
+                        post(
+                            |State(upload_dir): State<UploadDir>, multipart| async move {
+                                upload_review_image(claims(), State(upload_dir), multipart).await
+                            },
+                        ),
+                    )
+                    .with_state(upload_dir);
+
+                let boundary = "wildcard-review-boundary";
+                let response = app
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri("/upload")
+                            .header(
+                                header::CONTENT_TYPE,
+                                format!("multipart/form-data; boundary={boundary}"),
+                            )
+                            .body(Body::from(multipart_body(
+                                boundary,
+                                "image/png",
+                                b"png bytes",
+                            )))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+                let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                let url = json["data"]["imageUrl"].as_str().unwrap();
+                assert!(url.starts_with("/static/review-images/"));
+                let saved = upload_root.join(url.trim_start_matches("/static/"));
+                assert_eq!(tokio::fs::read(saved).await.unwrap(), b"png bytes");
+
+                let bad_boundary = "wildcard-review-bad-boundary";
+                let bad_response = app
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri("/upload")
+                            .header(
+                                header::CONTENT_TYPE,
+                                format!("multipart/form-data; boundary={bad_boundary}"),
+                            )
+                            .body(Body::from(multipart_body(
+                                bad_boundary,
+                                "image/gif",
+                                b"gif",
+                            )))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(bad_response.status(), StatusCode::BAD_REQUEST);
+                tokio::fs::remove_dir_all(upload_root).await.unwrap();
+            }
+        }
+    }
+}
+
+mod state {
+    use std::{path::PathBuf, sync::Arc};
+    use tokio::sync::RwLock;
+
+    #[derive(Clone, Debug)]
+    pub struct UploadDir(pub Arc<PathBuf>);
+
+    impl UploadDir {
+        pub fn from_path(path: PathBuf) -> Self {
+            Self(Arc::new(path))
+        }
+    }
+
+    pub type RoomStore = Arc<RwLock<crate::interface::room::RoomRepository>>;
+    pub type RuleStore = Arc<RwLock<crate::interface::rule::RuleRepository>>;
+}

--- a/tests/room_interface_coverage_tests.rs
+++ b/tests/room_interface_coverage_tests.rs
@@ -1,0 +1,748 @@
+#![allow(dead_code)]
+
+use std::{collections::HashMap, sync::Arc};
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+mod error {
+    pub use wildcard_backend::error::*;
+}
+
+mod domain {
+    pub mod room {
+        pub use wildcard_backend::domain::room::*;
+    }
+    pub mod rule_engine {
+        pub use wildcard_backend::domain::rule_engine::*;
+    }
+    pub mod user {
+        pub use wildcard_backend::domain::user::*;
+    }
+}
+
+mod infrastructure {
+    pub mod user {
+        use std::{collections::HashMap, sync::Arc};
+
+        use tokio::sync::RwLock;
+        use uuid::Uuid;
+
+        use crate::{
+            domain::user::{User, UserId},
+            error::AppError,
+        };
+
+        #[derive(Clone)]
+        struct StoredUser {
+            id: Uuid,
+            name: String,
+            email: String,
+            password: String,
+            avatar: String,
+            role: String,
+        }
+
+        impl StoredUser {
+            fn into_user(self) -> User {
+                User {
+                    id: UserId(self.id),
+                    name: self.name,
+                    email: self.email,
+                    password: self.password,
+                    avatar: self.avatar,
+                    role: self.role,
+                }
+            }
+        }
+
+        #[derive(Default)]
+        pub struct UserRepository {
+            users: Arc<RwLock<HashMap<Uuid, StoredUser>>>,
+        }
+
+        impl std::fmt::Debug for UserRepository {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("UserRepository").finish_non_exhaustive()
+            }
+        }
+
+        impl UserRepository {
+            pub fn with_users(users: Vec<User>) -> Self {
+                Self {
+                    users: Arc::new(RwLock::new(
+                        users
+                            .into_iter()
+                            .map(|user| {
+                                (
+                                    user.id.0,
+                                    StoredUser {
+                                        id: user.id.0,
+                                        name: user.name,
+                                        email: user.email,
+                                        password: user.password,
+                                        avatar: user.avatar,
+                                        role: user.role,
+                                    },
+                                )
+                            })
+                            .collect(),
+                    )),
+                }
+            }
+
+            pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
+                Ok(self
+                    .users
+                    .read()
+                    .await
+                    .get(&user_id.0)
+                    .cloned()
+                    .map(StoredUser::into_user))
+            }
+        }
+    }
+}
+
+mod interface {
+    pub mod auth {
+        use serde::{Deserialize, Serialize};
+
+        use crate::domain::user::UserId;
+
+        #[derive(Debug, Serialize, Deserialize)]
+        pub struct TokenClaims {
+            #[serde(rename = "sub")]
+            pub user_id: UserId,
+            pub iat: usize,
+            pub exp: usize,
+        }
+    }
+
+    pub mod user {
+        use serde::Serialize;
+
+        #[derive(Debug, Serialize)]
+        pub struct ApiResponse<T> {
+            pub success: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub data: Option<T>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub message: Option<String>,
+        }
+
+        impl<T> ApiResponse<T> {
+            pub(crate) fn success(data: T) -> Self {
+                Self {
+                    success: true,
+                    data: Some(data),
+                    message: None,
+                }
+            }
+
+            pub(crate) fn success_with_optional_data(data: Option<T>) -> Self {
+                Self {
+                    success: true,
+                    data,
+                    message: None,
+                }
+            }
+        }
+
+        impl ApiResponse<()> {
+            pub(crate) fn success_without_data(message: Option<String>) -> Self {
+                Self {
+                    success: true,
+                    data: None,
+                    message,
+                }
+            }
+        }
+    }
+
+    pub mod rule {
+        use std::collections::HashMap;
+
+        use crate::domain::rule_engine::{ExportedRuleDesign, RuntimeRule};
+
+        #[derive(Debug, Clone)]
+        pub struct PublishedRule {
+            pub id: String,
+            pub owner_id: String,
+            pub name: String,
+            pub player_count: u8,
+            pub description: String,
+            pub version: u32,
+            pub design: ExportedRuleDesign,
+            pub runtime: RuntimeRule,
+            pub created_at: i64,
+            pub updated_at: i64,
+            pub introduction: String,
+            pub cover_url: String,
+            pub screenshot_urls: Vec<String>,
+        }
+
+        #[derive(Debug, Default)]
+        pub struct RuleRepository {
+            pub published: HashMap<String, PublishedRule>,
+        }
+    }
+
+    pub mod room {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/interface/room.rs"
+        ));
+    }
+}
+
+mod state {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+    pub type RoomStore = Arc<RwLock<crate::interface::room::RoomRepository>>;
+    pub type RuleStore = Arc<RwLock<crate::interface::rule::RuleRepository>>;
+}
+
+use domain::{
+    room::{Player, Room, RoomStatus},
+    rule_engine::{ExportedRuleDesign, PlayerActionInput, RuleEngine},
+    user::{User, UserId},
+};
+use infrastructure::user::UserRepository;
+use interface::{
+    auth::TokenClaims,
+    room::{
+        CreateRoomRequest, CurrentGameQuery, JoinRoomRequest, ReadyRequest, RoomCodeQuery,
+        RuleQuery, build_room_store, check_password, choose_action, create_room, current_game,
+        current_room, get_game, get_room_rule, join_room, leave_room, play_cards, set_ready,
+        skip_action, start_game,
+    },
+    rule::{PublishedRule, RuleRepository},
+};
+use state::RuleStore;
+
+fn claims(id: Uuid) -> TokenClaims {
+    TokenClaims {
+        user_id: UserId(id),
+        iat: 0,
+        exp: usize::MAX,
+    }
+}
+
+fn user(id: Uuid, name: &str) -> User {
+    User {
+        id: UserId(id),
+        name: name.to_string(),
+        email: format!("{name}@example.com"),
+        password: "hashed".to_string(),
+        avatar: format!("/{name}.png"),
+        role: "user".to_string(),
+    }
+}
+
+fn player(id: &str, ready: bool, joined_at: i64) -> Player {
+    Player {
+        id: id.to_string(),
+        username: format!("user-{id}"),
+        avatar: String::new(),
+        is_ready: ready,
+        joined_at: Some(joined_at),
+    }
+}
+
+fn valid_design() -> ExportedRuleDesign {
+    let content = std::fs::read_to_string(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test2.json"),
+    )
+    .expect("test fixture should exist");
+    serde_json::from_str(&content).expect("test fixture should parse")
+}
+
+fn published_rule(id: &str, name: &str) -> PublishedRule {
+    let design = valid_design();
+    let runtime = RuleEngine::parse(name.to_string(), 2, "desc".to_string(), design.clone())
+        .expect("fixture rule should compile");
+    PublishedRule {
+        id: id.to_string(),
+        owner_id: Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        player_count: 2,
+        description: "desc".to_string(),
+        version: 1,
+        design,
+        runtime,
+        created_at: 1,
+        updated_at: 1,
+        introduction: "intro".to_string(),
+        cover_url: "/static/rule-images/cover.png".to_string(),
+        screenshot_urls: vec!["/static/rule-images/shot.png".to_string()],
+    }
+}
+
+fn rule_store(rule: PublishedRule) -> RuleStore {
+    Arc::new(RwLock::new(RuleRepository {
+        published: HashMap::from([(rule.id.clone(), rule)]),
+    }))
+}
+
+fn room(code: &str, host_id: &str, players: Vec<Player>) -> Room {
+    Room {
+        id: format!("room-{code}"),
+        code: code.to_string(),
+        host_id: host_id.to_string(),
+        player_count: 2,
+        round_time: 20,
+        rule_id: "tiny".to_string(),
+        rule_name: "Tiny".to_string(),
+        password: None,
+        has_password: false,
+        players,
+        status: RoomStatus::Waiting,
+        game_session_id: None,
+    }
+}
+
+#[test]
+fn domain_room_catalog_and_serialization_cover_public_contracts() {
+    let catalog = wildcard_backend::domain::room::default_rule_catalog();
+    assert!(catalog.contains_key("classic"));
+    assert!(catalog.contains_key("party"));
+    assert_eq!(catalog["classic"].option.player_count, 4);
+
+    let value = serde_json::to_value(wildcard_backend::domain::room::Room {
+        id: "room-1".to_string(),
+        code: "ABC123".to_string(),
+        host_id: "host".to_string(),
+        player_count: 2,
+        round_time: 30,
+        rule_id: "rule-1".to_string(),
+        rule_name: "Rule".to_string(),
+        password: Some("secret".to_string()),
+        has_password: true,
+        players: vec![wildcard_backend::domain::room::Player {
+            id: "host".to_string(),
+            username: "host-user".to_string(),
+            avatar: String::new(),
+            is_ready: true,
+            joined_at: Some(10),
+        }],
+        status: wildcard_backend::domain::room::RoomStatus::Playing,
+        game_session_id: Some("session-1".to_string()),
+    })
+    .expect("room should serialize");
+
+    assert_eq!(value["hostId"], "host");
+    assert_eq!(value["hasPassword"], true);
+    assert_eq!(value["players"][0]["isReady"], true);
+    assert_eq!(value["status"], "playing");
+    assert_eq!(value["gameSessionId"], "session-1");
+}
+
+#[tokio::test]
+async fn room_lifecycle_endpoints_cover_create_join_ready_rule_and_leave() {
+    let host = Uuid::new_v4();
+    let guest = Uuid::new_v4();
+    let user_repo = Arc::new(UserRepository::with_users(vec![
+        user(host, "host"),
+        user(guest, "guest"),
+    ]));
+    let room_store = build_room_store();
+    let rules = rule_store(published_rule("tiny", "Tiny"));
+
+    let created = create_room(
+        claims(host),
+        State(user_repo.clone()),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Json(CreateRoomRequest {
+            rule_id: "tiny".to_string(),
+            round_time: 30,
+            password: Some(" secret ".to_string()),
+        }),
+    )
+    .await
+    .expect("host should create room")
+    .0
+    .data
+    .expect("room should be returned");
+    assert_eq!(created.password, None);
+    assert!(created.has_password);
+
+    let code = created.code.clone();
+    let password = check_password(
+        State(room_store.clone()),
+        Query(RoomCodeQuery {
+            code: Some(code.to_lowercase()),
+        }),
+    )
+    .await
+    .0;
+    assert!(password.has_password);
+
+    let wrong_password = join_room(
+        claims(guest),
+        State(user_repo.clone()),
+        State(room_store.clone()),
+        Json(JoinRoomRequest {
+            code: code.clone(),
+            password: Some("bad".to_string()),
+        }),
+    )
+    .await;
+    assert!(wrong_password.is_err());
+
+    let joined = join_room(
+        claims(guest),
+        State(user_repo.clone()),
+        State(room_store.clone()),
+        Json(JoinRoomRequest {
+            code: code.clone(),
+            password: Some("secret".to_string()),
+        }),
+    )
+    .await
+    .expect("guest should join")
+    .0
+    .data
+    .expect("joined room should be returned");
+    assert_eq!(joined.players.len(), 2);
+
+    let current_by_member = current_room(
+        claims(guest),
+        State(room_store.clone()),
+        Query(RoomCodeQuery { code: None }),
+    )
+    .await
+    .expect("current room should resolve by membership")
+    .0
+    .data
+    .flatten()
+    .expect("room should be present");
+    assert_eq!(current_by_member.code, code);
+
+    let current_by_code = current_room(
+        claims(guest),
+        State(room_store.clone()),
+        Query(RoomCodeQuery {
+            code: Some(code.to_lowercase()),
+        }),
+    )
+    .await
+    .expect("current room should resolve by code")
+    .0
+    .data
+    .flatten()
+    .expect("room should be present");
+    assert_eq!(current_by_code.players.len(), 2);
+
+    let host_unready = set_ready(
+        claims(host),
+        State(room_store.clone()),
+        Json(ReadyRequest { is_ready: false }),
+    )
+    .await
+    .expect("host cannot become unready while waiting")
+    .0
+    .data
+    .expect("room should be returned");
+    assert!(
+        host_unready
+            .players
+            .iter()
+            .any(|p| p.id == host.to_string() && p.is_ready)
+    );
+
+    let _ = set_ready(
+        claims(guest),
+        State(room_store.clone()),
+        Json(ReadyRequest { is_ready: true }),
+    )
+    .await
+    .expect("guest should ready");
+
+    let rule_response = get_room_rule(
+        claims(guest),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Query(RuleQuery { room_id: None }),
+    )
+    .await
+    .expect("member should read room rule")
+    .0
+    .data
+    .expect("rule should be returned");
+    assert!(rule_response.rule["classes"].is_object());
+
+    let started = start_game(
+        claims(host),
+        State(rules.clone()),
+        State(room_store.clone()),
+    )
+    .await
+    .expect("host should start full ready room")
+    .0
+    .data
+    .expect("started room should be returned");
+    assert_eq!(started.status, RoomStatus::Playing);
+    assert!(started.game_session_id.is_some());
+
+    let leave_started = leave_room(claims(guest), State(room_store.clone()))
+        .await
+        .expect("guest can leave started room")
+        .0;
+    assert!(leave_started.success);
+
+    let guard = room_store.read().await;
+    let room = guard.rooms.get(&code).expect("room remains for host");
+    assert_eq!(room.status, RoomStatus::Waiting);
+    assert_eq!(room.game_session_id, None);
+}
+
+#[tokio::test]
+async fn room_game_queries_and_actions_cover_snapshot_error_and_finish_paths() {
+    let host = Uuid::new_v4();
+    let guest = Uuid::new_v4();
+    let user_repo = Arc::new(UserRepository::with_users(vec![
+        user(host, "host"),
+        user(guest, "guest"),
+    ]));
+    let room_store = build_room_store();
+    let rules = rule_store(published_rule("tiny", "Tiny"));
+
+    let created = create_room(
+        claims(host),
+        State(user_repo.clone()),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Json(CreateRoomRequest {
+            rule_id: "tiny".to_string(),
+            round_time: 15,
+            password: None,
+        }),
+    )
+    .await
+    .expect("host should create room")
+    .0
+    .data
+    .expect("room should be returned");
+
+    let _ = join_room(
+        claims(guest),
+        State(user_repo.clone()),
+        State(room_store.clone()),
+        Json(JoinRoomRequest {
+            code: created.code.clone(),
+            password: None,
+        }),
+    )
+    .await
+    .expect("guest should join");
+    let _ = set_ready(
+        claims(guest),
+        State(room_store.clone()),
+        Json(ReadyRequest { is_ready: true }),
+    )
+    .await
+    .expect("guest should ready");
+
+    let not_host = start_game(
+        claims(guest),
+        State(rules.clone()),
+        State(room_store.clone()),
+    )
+    .await;
+    assert!(not_host.is_err());
+
+    let started = start_game(
+        claims(host),
+        State(rules.clone()),
+        State(room_store.clone()),
+    )
+    .await
+    .expect("host should start room")
+    .0
+    .data
+    .expect("started room should be returned");
+    let session_id = started
+        .game_session_id
+        .clone()
+        .expect("session id should exist");
+
+    let snapshot = current_game(
+        claims(host),
+        State(room_store.clone()),
+        Query(CurrentGameQuery {
+            room_code: Some(created.code.to_lowercase()),
+        }),
+    )
+    .await
+    .expect("current game should resolve by room code")
+    .0
+    .data
+    .expect("snapshot should be returned");
+    assert_eq!(snapshot.status, "playing");
+    assert_eq!(snapshot.round_time, 15);
+    assert!(snapshot.pending_action.is_some());
+    assert!(!snapshot.hand_cards.is_empty());
+
+    let direct_snapshot = get_game(
+        claims(host),
+        State(room_store.clone()),
+        Path(session_id.clone()),
+    )
+    .await
+    .expect("snapshot should resolve by session id")
+    .0
+    .data
+    .expect("snapshot should be returned");
+    assert_eq!(direct_snapshot.session_id, session_id);
+
+    let wrong_action = play_cards(
+        claims(host),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Path((session_id.clone(), "not-the-pending-action".to_string())),
+        Json(PlayerActionInput {
+            cards: Vec::new(),
+            choice: None,
+        }),
+    )
+    .await;
+    assert!(wrong_action.is_err());
+
+    let pending = direct_snapshot
+        .pending_action
+        .expect("pending action should exist");
+    let first_card = direct_snapshot
+        .hand_cards
+        .first()
+        .expect("host should have a card")
+        .id
+        .clone();
+    let finished = choose_action(
+        claims(host),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Path((session_id.clone(), pending.action_id.clone())),
+        Json(PlayerActionInput {
+            cards: vec![first_card],
+            choice: None,
+        }),
+    )
+    .await
+    .expect("valid action should finish tiny rule")
+    .0
+    .data
+    .expect("finished snapshot should be returned");
+    assert_eq!(finished.status, "finished");
+    assert_eq!(finished.last_action.as_ref().unwrap().action, "play_cards");
+    assert_eq!(finished.winner_ids, vec![host.to_string()]);
+
+    let after_finish = current_game(
+        claims(guest),
+        State(room_store.clone()),
+        Query(CurrentGameQuery {
+            room_code: Some(started.code),
+        }),
+    )
+    .await
+    .expect("finished session should still be queryable")
+    .0
+    .data
+    .expect("snapshot should be returned");
+    assert_eq!(after_finish.status, "finished");
+
+    let skip_after_finished = skip_action(
+        claims(guest),
+        State(rules.clone()),
+        State(room_store.clone()),
+        Path((session_id, pending.action_id)),
+    )
+    .await;
+    assert!(skip_after_finished.is_err());
+}
+
+#[tokio::test]
+async fn room_repository_paths_cover_host_rotation_full_rooms_and_missing_data() {
+    let host = Uuid::new_v4().to_string();
+    let guest = Uuid::new_v4().to_string();
+    let third = Uuid::new_v4();
+    let room_store = build_room_store();
+    {
+        let mut guard = room_store.write().await;
+        guard.player_rooms.insert(host.clone(), "ROOMX".to_string());
+        guard
+            .player_rooms
+            .insert(guest.clone(), "ROOMX".to_string());
+        guard.rooms.insert(
+            "ROOMX".to_string(),
+            room(
+                "ROOMX",
+                &host,
+                vec![player(&host, true, 20), player(&guest, false, 10)],
+            ),
+        );
+    }
+
+    let users = Arc::new(UserRepository::with_users(vec![user(third, "third")]));
+    let full_join = join_room(
+        claims(third),
+        State(users),
+        State(room_store.clone()),
+        Json(JoinRoomRequest {
+            code: "ROOMX".to_string(),
+            password: None,
+        }),
+    )
+    .await;
+    assert!(full_join.is_err());
+
+    let _ = leave_room(
+        claims(Uuid::parse_str(&host).unwrap()),
+        State(room_store.clone()),
+    )
+    .await
+    .expect("host can leave");
+    {
+        let guard = room_store.read().await;
+        let room = guard.rooms.get("ROOMX").expect("guest keeps room alive");
+        assert_eq!(room.host_id, guest);
+        assert!(room.players.iter().all(|player| player.is_ready));
+    }
+
+    let missing_current = current_room(
+        claims(third),
+        State(room_store.clone()),
+        Query(RoomCodeQuery { code: None }),
+    )
+    .await
+    .expect("missing membership returns empty success")
+    .0
+    .data
+    .flatten();
+    assert!(missing_current.is_none());
+
+    let missing_password = check_password(
+        State(room_store.clone()),
+        Query(RoomCodeQuery {
+            code: Some("missing".to_string()),
+        }),
+    )
+    .await
+    .0;
+    assert!(!missing_password.has_password);
+
+    let _ = leave_room(
+        claims(Uuid::parse_str(&guest).unwrap()),
+        State(room_store.clone()),
+    )
+    .await
+    .expect("last player can leave");
+    let guard = room_store.read().await;
+    assert!(!guard.rooms.contains_key("ROOMX"));
+}

--- a/tests/rule_interface_coverage_tests.rs
+++ b/tests/rule_interface_coverage_tests.rs
@@ -1,0 +1,887 @@
+#![allow(dead_code)]
+#![allow(deprecated)]
+
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use axum::{Json, extract::Path, extract::State};
+use sqlx::postgres::PgPoolOptions;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+mod error {
+    pub use wildcard_backend::error::*;
+}
+
+mod domain {
+    pub mod user {
+        pub use wildcard_backend::domain::user::*;
+    }
+
+    pub mod rule_engine {
+        pub use wildcard_backend::domain::rule_engine::*;
+    }
+}
+
+mod infrastructure {
+    pub mod user {
+        use std::{collections::HashMap, sync::Arc};
+
+        use tokio::sync::RwLock;
+        use uuid::Uuid;
+
+        use crate::{
+            domain::user::{User, UserId},
+            error::AppError,
+        };
+
+        #[derive(Clone, Debug)]
+        struct StoredUser {
+            id: Uuid,
+            name: String,
+            email: String,
+            password: String,
+            avatar: String,
+            role: String,
+        }
+
+        impl StoredUser {
+            fn into_user(self) -> User {
+                User {
+                    id: UserId(self.id),
+                    name: self.name,
+                    email: self.email,
+                    password: self.password,
+                    avatar: self.avatar,
+                    role: self.role,
+                }
+            }
+        }
+
+        #[derive(Debug, Default)]
+        pub struct UserRepository {
+            users: Arc<RwLock<HashMap<Uuid, StoredUser>>>,
+        }
+
+        impl UserRepository {
+            pub fn with_users(users: Vec<User>) -> Self {
+                Self {
+                    users: Arc::new(RwLock::new(
+                        users
+                            .into_iter()
+                            .map(|user| {
+                                (
+                                    user.id.0,
+                                    StoredUser {
+                                        id: user.id.0,
+                                        name: user.name,
+                                        email: user.email,
+                                        password: user.password,
+                                        avatar: user.avatar,
+                                        role: user.role,
+                                    },
+                                )
+                            })
+                            .collect(),
+                    )),
+                }
+            }
+
+            pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
+                Ok(self
+                    .users
+                    .read()
+                    .await
+                    .get(&user_id.0)
+                    .cloned()
+                    .map(StoredUser::into_user))
+            }
+        }
+    }
+}
+
+mod interface {
+    pub mod auth {
+        use serde::{Deserialize, Serialize};
+
+        use crate::domain::user::UserId;
+
+        #[derive(Debug, Serialize, Deserialize)]
+        pub struct TokenClaims {
+            #[serde(rename = "sub")]
+            pub user_id: UserId,
+            pub iat: usize,
+            pub exp: usize,
+        }
+    }
+
+    pub mod user {
+        pub fn extension_for_mime(mime: &str) -> Option<&'static str> {
+            match mime {
+                "image/png" => Some("png"),
+                "image/jpeg" | "image/jpg" => Some("jpg"),
+                "image/webp" => Some("webp"),
+                _ => None,
+            }
+        }
+    }
+
+    pub mod rule {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/interface/rule.rs"
+        ));
+    }
+}
+
+mod state {
+    use std::{path::PathBuf, sync::Arc};
+
+    use tokio::sync::RwLock;
+
+    use crate::interface::rule::RuleRepository;
+
+    pub type RuleStore = Arc<RwLock<RuleRepository>>;
+
+    #[derive(Clone)]
+    pub struct UploadDir(pub Arc<PathBuf>);
+
+    impl UploadDir {
+        pub fn from_path(path: PathBuf) -> Self {
+            Self(Arc::new(path))
+        }
+    }
+}
+
+use domain::{
+    rule_engine::{ExportedRuleDesign, RuleEngine},
+    user::{User, UserId},
+};
+use error::AppError;
+use infrastructure::user::UserRepository;
+use interface::{
+    auth::TokenClaims,
+    rule::{
+        self, ForkRuleRequest, PublishedRule, RuleDraft, RulePersistence, RuleRepository,
+        RuleStatus, SaveRuleDraftRequest,
+    },
+};
+use state::RuleStore;
+
+fn claims(user_id: Uuid) -> TokenClaims {
+    TokenClaims {
+        user_id: UserId(user_id),
+        iat: 0,
+        exp: usize::MAX,
+    }
+}
+
+fn empty_design() -> ExportedRuleDesign {
+    ExportedRuleDesign {
+        classes: HashMap::new(),
+        cardsets: HashMap::new(),
+        cardset_comparisons: HashMap::new(),
+        match_flow: HashMap::new(),
+        end_flow: HashMap::new(),
+    }
+}
+
+fn valid_design() -> ExportedRuleDesign {
+    let content =
+        std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("war.json"))
+            .expect("war fixture should exist");
+    serde_json::from_str(&content).expect("war fixture should parse")
+}
+
+fn published_rule(id: &str, name: &str) -> PublishedRule {
+    let design = valid_design();
+    let runtime = RuleEngine::parse(name.to_string(), 2, "desc".to_string(), design.clone())
+        .expect("fixture rule should compile");
+    PublishedRule {
+        id: id.to_string(),
+        owner_id: Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        player_count: 2,
+        description: "desc".to_string(),
+        version: 1,
+        design,
+        runtime,
+        created_at: 1,
+        updated_at: 1,
+        introduction: "intro".to_string(),
+        cover_url: "/static/rule-images/cover.png".to_string(),
+        screenshot_urls: vec!["/static/rule-images/shot.png".to_string()],
+    }
+}
+
+fn draft(owner_id: Uuid, id: &str, status: RuleStatus, updated_at: i64) -> RuleDraft {
+    RuleDraft {
+        id: id.to_string(),
+        owner_id: owner_id.to_string(),
+        name: format!("draft-{id}"),
+        player_count: 2,
+        description: "desc".to_string(),
+        status,
+        design: valid_design(),
+        created_at: 1,
+        updated_at,
+        published_rule_id: None,
+        forked_from_rule_id: None,
+        reject_reason: None,
+        introduction: "intro".to_string(),
+        cover_url: String::new(),
+        screenshot_urls: Vec::new(),
+    }
+}
+
+fn store_with(drafts: Vec<RuleDraft>, published: Vec<PublishedRule>) -> RuleStore {
+    Arc::new(RwLock::new(RuleRepository {
+        drafts: drafts
+            .into_iter()
+            .map(|draft| (draft.id.clone(), draft))
+            .collect(),
+        published: published
+            .into_iter()
+            .map(|rule| (rule.id.clone(), rule))
+            .collect(),
+    }))
+}
+
+fn persistence() -> RulePersistence {
+    RulePersistence {
+        pool: PgPoolOptions::new()
+            .connect_lazy("postgres://user:password@localhost/wildcard_test")
+            .unwrap(),
+    }
+}
+
+#[tokio::test]
+async fn rule_draft_read_paths_filter_sort_and_check_ownership() {
+    let owner = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let mut old = draft(owner, "old", RuleStatus::Draft, 10);
+    old.published_rule_id = Some("rule-old".to_string());
+    old.reject_reason = Some("needs work".to_string());
+    let new = draft(owner, "new", RuleStatus::Rejected, 20);
+    let hidden = draft(other, "hidden", RuleStatus::Draft, 30);
+    let store = store_with(vec![old, new, hidden], Vec::new());
+
+    let Json(response) = rule::list_drafts(claims(owner), State(store.clone()))
+        .await
+        .unwrap();
+    let drafts = response.data.unwrap();
+    assert_eq!(
+        drafts
+            .iter()
+            .map(|draft| draft.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["new", "old"]
+    );
+    assert_eq!(drafts[1].published_rule_id.as_deref(), Some("rule-old"));
+    assert_eq!(drafts[1].reject_reason.as_deref(), Some("needs work"));
+
+    let Json(response) =
+        rule::get_draft(claims(owner), State(store.clone()), Path("old".to_string()))
+            .await
+            .unwrap();
+    assert_eq!(response.data.unwrap().id, "old");
+
+    let unauthorized =
+        rule::get_draft(claims(other), State(store.clone()), Path("old".to_string()))
+            .await
+            .unwrap_err();
+    assert!(matches!(unauthorized, AppError::Unauthorized(_)));
+
+    let missing = rule::get_draft(claims(owner), State(store), Path("missing".to_string()))
+        .await
+        .unwrap_err();
+    assert!(matches!(missing, AppError::NotFound));
+}
+
+#[tokio::test]
+async fn rule_write_paths_exercise_early_errors_without_database() {
+    let owner = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let mut pending = draft(owner, "pending", RuleStatus::PendingReview, 88);
+    pending.reject_reason = Some("old reason".to_string());
+    let mut invalid = draft(owner, "invalid", RuleStatus::Draft, 1);
+    invalid.name = "   ".to_string();
+    let store = store_with(vec![pending, invalid], Vec::new());
+
+    let Json(response) = rule::submit_review(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Path("pending".to_string()),
+    )
+    .await
+    .unwrap();
+    let data = response.data.unwrap();
+    assert_eq!(data.id, "pending");
+    assert_eq!(data.status, RuleStatus::PendingReview);
+    assert_eq!(data.updated_at, 88);
+
+    let unauthorized = rule::delete_draft(
+        claims(other),
+        State(store.clone()),
+        State(persistence()),
+        Path("pending".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(unauthorized, AppError::Unauthorized(_)));
+
+    let missing = rule::delete_draft(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Path("missing".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(missing, AppError::NotFound));
+
+    let parse_error = rule::publish_draft(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Path("invalid".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(parse_error, AppError::InvalidInput(_)));
+
+    let save_error = rule::save_draft(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Json(SaveRuleDraftRequest {
+            name: "bad".to_string(),
+            player_count: 2,
+            description: String::new(),
+            design: empty_design(),
+            introduction: String::new(),
+            cover_url: String::new(),
+            screenshot_urls: Vec::new(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(save_error, AppError::InvalidInput(_)));
+
+    let update_error = rule::update_draft(
+        claims(owner),
+        State(store),
+        State(persistence()),
+        Path("pending".to_string()),
+        Json(SaveRuleDraftRequest {
+            name: "War".to_string(),
+            player_count: 2,
+            description: String::new(),
+            design: valid_design(),
+            introduction: String::new(),
+            cover_url: "not-a-url".to_string(),
+            screenshot_urls: Vec::new(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(update_error, AppError::InvalidInput(_)));
+}
+
+#[tokio::test]
+async fn fork_and_options_paths_cover_sorting_and_pre_persistence_validation() {
+    let owner = Uuid::new_v4();
+    let store = store_with(
+        Vec::new(),
+        vec![
+            published_rule("rule-z", "Alpha"),
+            published_rule("party", "Party"),
+            published_rule("classic", "Classic"),
+            published_rule("rule-a", "Beta"),
+        ],
+    );
+
+    let missing = rule::fork_published_rule(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Path("missing".to_string()),
+        Json(ForkRuleRequest {
+            name: "copy".to_string(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(missing, AppError::NotFound));
+
+    let too_long = rule::fork_published_rule(
+        claims(owner),
+        State(store.clone()),
+        State(persistence()),
+        Path("classic".to_string()),
+        Json(ForkRuleRequest {
+            name: "x".repeat(300),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(too_long, AppError::InvalidInput(_)));
+
+    let Json(response) = rule::rule_options(State(store)).await.unwrap();
+    let ids = response
+        .data
+        .unwrap()
+        .into_iter()
+        .map(|option| option.id)
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["classic", "party", "rule-a", "rule-z"]);
+}
+
+#[tokio::test]
+async fn admin_endpoints_stop_on_auth_guard_with_fake_repository() {
+    let user_id = Uuid::new_v4();
+    let normal_user = User {
+        id: UserId(user_id),
+        name: "Normal".to_string(),
+        email: "normal@example.com".to_string(),
+        password: "hashed".to_string(),
+        avatar: String::new(),
+        role: "user".to_string(),
+    };
+    let repo = Arc::new(UserRepository::with_users(vec![normal_user]));
+    let store = store_with(
+        vec![draft(user_id, "pending", RuleStatus::PendingReview, 1)],
+        Vec::new(),
+    );
+
+    let list_error =
+        rule::list_pending_reviews(claims(user_id), State(store.clone()), State(repo.clone()))
+            .await
+            .unwrap_err();
+    assert!(matches!(list_error, AppError::Forbidden(_)));
+
+    let get_error = rule::admin_get_draft(
+        claims(user_id),
+        State(store.clone()),
+        State(repo.clone()),
+        Path("pending".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(get_error, AppError::Forbidden(_)));
+
+    let approve_error = rule::approve_draft(
+        claims(user_id),
+        State(store.clone()),
+        State(persistence()),
+        State(repo.clone()),
+        Path("pending".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(approve_error, AppError::Forbidden(_)));
+
+    let reject_error = rule::reject_draft(
+        claims(user_id),
+        State(store),
+        State(persistence()),
+        State(repo),
+        Path("pending".to_string()),
+        Json(rule::RejectDraftRequest {
+            reason: "not acceptable".to_string(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(reject_error, AppError::Forbidden(_)));
+}
+
+fn failing_persistence() -> RulePersistence {
+    RulePersistence {
+        pool: PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(50))
+            .connect_lazy("postgres://user:password@127.0.0.1:1/wildcard_test")
+            .unwrap(),
+    }
+}
+
+#[tokio::test]
+async fn persistence_methods_cover_uuid_validation_and_database_error_paths() {
+    let persistence = failing_persistence();
+    assert!(persistence.ensure_schema().await.is_err());
+
+    let mut repository = RuleRepository::default();
+    assert!(persistence.load_into(&mut repository).await.is_err());
+
+    let owner = Uuid::new_v4();
+    let draft_id = Uuid::new_v4().to_string();
+    let valid_draft = draft(owner, &draft_id, RuleStatus::Draft, 10);
+
+    let mut invalid_owner = valid_draft.clone();
+    invalid_owner.owner_id = "not-a-uuid".to_string();
+    assert!(matches!(
+        persistence.save_draft(&invalid_owner).await.unwrap_err(),
+        AppError::InvalidInput(_)
+    ));
+
+    let mut invalid_draft_id = valid_draft.clone();
+    invalid_draft_id.id = "not-a-uuid".to_string();
+    assert!(matches!(
+        persistence.save_draft(&invalid_draft_id).await.unwrap_err(),
+        AppError::InvalidInput(_)
+    ));
+
+    assert!(persistence.save_draft(&valid_draft).await.is_err());
+
+    let mut published = published_rule(&format!("rule_{}", Uuid::new_v4()), "Published");
+    published.owner_id = owner.to_string();
+    assert!(
+        persistence
+            .save_published_rule(&published, &draft_id)
+            .await
+            .is_err()
+    );
+
+    let mut invalid_rule = published.clone();
+    invalid_rule.id = "not-a-uuid".to_string();
+    assert!(matches!(
+        persistence
+            .save_published_rule(&invalid_rule, &draft_id)
+            .await
+            .unwrap_err(),
+        AppError::InvalidInput(_)
+    ));
+
+    assert!(matches!(
+        persistence
+            .delete_draft("not-a-uuid", &owner.to_string())
+            .await
+            .unwrap_err(),
+        AppError::InvalidInput(_)
+    ));
+    assert!(
+        persistence
+            .delete_draft(&draft_id, &owner.to_string())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn admin_review_success_and_conflict_paths_cover_authorized_flow() {
+    let admin_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin = User {
+        id: UserId(admin_id),
+        name: "Admin".to_string(),
+        email: "admin@example.com".to_string(),
+        password: "hashed".to_string(),
+        avatar: String::new(),
+        role: "admin".to_string(),
+    };
+    let owner = User {
+        id: UserId(owner_id),
+        name: "Owner".to_string(),
+        email: "owner@example.com".to_string(),
+        password: "hashed".to_string(),
+        avatar: String::new(),
+        role: "user".to_string(),
+    };
+    let repo = Arc::new(UserRepository::with_users(vec![admin, owner]));
+    let mut pending_old = draft(owner_id, "pending-old", RuleStatus::PendingReview, 1);
+    pending_old.name = "Old".to_string();
+    let mut pending_new = draft(owner_id, "pending-new", RuleStatus::PendingReview, 5);
+    pending_new.name = "New".to_string();
+    let draft_status = draft(owner_id, "draft-status", RuleStatus::Draft, 10);
+    let store = store_with(vec![pending_new, pending_old, draft_status], Vec::new());
+
+    let Json(list_response) =
+        rule::list_pending_reviews(claims(admin_id), State(store.clone()), State(repo.clone()))
+            .await
+            .unwrap();
+    let pending = list_response.data.unwrap();
+    assert_eq!(
+        pending
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Old", "New"]
+    );
+    assert_eq!(pending[0].owner_name, "Owner");
+
+    let Json(preview) = rule::admin_get_draft(
+        claims(admin_id),
+        State(store.clone()),
+        State(repo.clone()),
+        Path("pending-old".to_string()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(preview.data.unwrap().id, "pending-old");
+
+    let missing_preview = rule::admin_get_draft(
+        claims(admin_id),
+        State(store.clone()),
+        State(repo.clone()),
+        Path("missing".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(missing_preview, AppError::NotFound));
+
+    let approve_conflict = rule::approve_draft(
+        claims(admin_id),
+        State(store.clone()),
+        State(failing_persistence()),
+        State(repo.clone()),
+        Path("draft-status".to_string()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(approve_conflict, AppError::Conflict(_)));
+
+    let reject_conflict = rule::reject_draft(
+        claims(admin_id),
+        State(store),
+        State(failing_persistence()),
+        State(repo),
+        Path("draft-status".to_string()),
+        Json(rule::RejectDraftRequest {
+            reason: "valid reason".to_string(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(reject_conflict, AppError::Conflict(_)));
+}
+
+fn multipart_body(boundary: &str, content_type: &str, bytes: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"rule.png\"\r\n",
+    );
+    body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    body
+}
+
+fn valid_save_payload(name: &str) -> SaveRuleDraftRequest {
+    SaveRuleDraftRequest {
+        name: name.to_string(),
+        player_count: 2,
+        description: "desc".to_string(),
+        design: valid_design(),
+        introduction: "intro".to_string(),
+        cover_url: "/static/rule-images/cover.png".to_string(),
+        screenshot_urls: vec!["/static/rule-images/shot.png".to_string()],
+    }
+}
+
+#[tokio::test]
+async fn valid_author_write_paths_reach_persistence_error_branches() {
+    let owner = Uuid::new_v4();
+
+    let save_error = rule::save_draft(
+        claims(owner),
+        State(store_with(Vec::new(), Vec::new())),
+        State(failing_persistence()),
+        Json(valid_save_payload("Save Valid")),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(save_error, AppError::DatabaseError(_)));
+
+    let update_id = Uuid::new_v4().to_string();
+    let update_store = store_with(
+        vec![draft(owner, &update_id, RuleStatus::Draft, 1)],
+        Vec::new(),
+    );
+    let update_error = rule::update_draft(
+        claims(owner),
+        State(update_store),
+        State(failing_persistence()),
+        Path(update_id),
+        Json(valid_save_payload("Update Valid")),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(update_error, AppError::DatabaseError(_)));
+
+    let delete_id = Uuid::new_v4().to_string();
+    let mut deleted = draft(owner, &delete_id, RuleStatus::Published, 1);
+    deleted.published_rule_id = Some("rule-to-remove".to_string());
+    let delete_store = store_with(
+        vec![deleted],
+        vec![published_rule("rule-to-remove", "Remove")],
+    );
+    let delete_error = rule::delete_draft(
+        claims(owner),
+        State(delete_store),
+        State(failing_persistence()),
+        Path(delete_id),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(delete_error, AppError::DatabaseError(_)));
+
+    let submit_id = Uuid::new_v4().to_string();
+    let submit_store = store_with(
+        vec![draft(owner, &submit_id, RuleStatus::Draft, 1)],
+        Vec::new(),
+    );
+    let submit_error = rule::submit_review(
+        claims(owner),
+        State(submit_store),
+        State(failing_persistence()),
+        Path(submit_id),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(submit_error, AppError::DatabaseError(_)));
+}
+
+#[tokio::test]
+async fn admin_approve_reject_pending_paths_reach_persistence_error_branches() {
+    let admin_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin = User {
+        id: UserId(admin_id),
+        name: "Admin".to_string(),
+        email: "admin@example.com".to_string(),
+        password: "hashed".to_string(),
+        avatar: String::new(),
+        role: "admin".to_string(),
+    };
+    let repo = Arc::new(UserRepository::with_users(vec![admin]));
+
+    let approve_id = Uuid::new_v4().to_string();
+    let approve_store = store_with(
+        vec![draft(owner_id, &approve_id, RuleStatus::PendingReview, 1)],
+        Vec::new(),
+    );
+    let approve_error = rule::approve_draft(
+        claims(admin_id),
+        State(approve_store),
+        State(failing_persistence()),
+        State(repo.clone()),
+        Path(approve_id),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(approve_error, AppError::DatabaseError(_)));
+
+    let reject_id = Uuid::new_v4().to_string();
+    let reject_store = store_with(
+        vec![draft(owner_id, &reject_id, RuleStatus::PendingReview, 1)],
+        Vec::new(),
+    );
+    let reject_error = rule::reject_draft(
+        claims(admin_id),
+        State(reject_store),
+        State(failing_persistence()),
+        State(repo),
+        Path(reject_id),
+        Json(rule::RejectDraftRequest {
+            reason: "needs changes".to_string(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(reject_error, AppError::DatabaseError(_)));
+}
+
+#[tokio::test]
+async fn upload_rule_image_covers_success_and_validation_errors() {
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request, StatusCode, header},
+        routing::post,
+    };
+    use tower::ServiceExt;
+
+    let owner = Uuid::new_v4();
+    let draft_id = Uuid::new_v4().to_string();
+    let store = store_with(
+        vec![draft(owner, &draft_id, RuleStatus::Draft, 1)],
+        Vec::new(),
+    );
+    let upload_root = std::env::temp_dir().join(format!("wildcard-rule-upload-{}", Uuid::new_v4()));
+    let upload_dir = state::UploadDir::from_path(upload_root.clone());
+    let app_state = (store.clone(), upload_dir.clone(), owner, draft_id.clone());
+    let app = Router::new()
+        .route(
+            "/upload",
+            post(
+                |State((store, upload_dir, owner, draft_id)): State<(
+                    RuleStore,
+                    state::UploadDir,
+                    Uuid,
+                    String,
+                )>,
+                 multipart| async move {
+                    rule::upload_rule_image(
+                        claims(owner),
+                        State(store),
+                        State(upload_dir),
+                        Path(draft_id),
+                        multipart,
+                    )
+                    .await
+                },
+            ),
+        )
+        .with_state(app_state);
+
+    let boundary = "wildcard-rule-boundary";
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/upload")
+                .header(
+                    header::CONTENT_TYPE,
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(multipart_body(
+                    boundary,
+                    "image/png",
+                    b"rule image",
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let url = json["data"]["imageUrl"].as_str().unwrap();
+    assert!(url.starts_with("/static/rule-images/"));
+    let saved = upload_root.join(url.trim_start_matches("/static/"));
+    assert_eq!(tokio::fs::read(saved).await.unwrap(), b"rule image");
+
+    let bad_boundary = "wildcard-rule-bad-boundary";
+    let bad_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/upload")
+                .header(
+                    header::CONTENT_TYPE,
+                    format!("multipart/form-data; boundary={bad_boundary}"),
+                )
+                .body(Body::from(multipart_body(
+                    bad_boundary,
+                    "image/gif",
+                    b"gif",
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(bad_response.status(), StatusCode::BAD_REQUEST);
+    tokio::fs::remove_dir_all(upload_root).await.unwrap();
+}

--- a/tests/user_login_avatar_http_tests.rs
+++ b/tests/user_login_avatar_http_tests.rs
@@ -6,7 +6,7 @@ use axum::{
     Router,
     body::{Body, to_bytes},
     http::{Request, StatusCode, header},
-    routing::post,
+    routing::{get, post},
 };
 use serde_json::{Value, json};
 use tokio::sync::RwLock;
@@ -326,7 +326,25 @@ fn test_state(upload_dir: PathBuf, avatar: &str) -> TestState {
 
 fn app(state: TestState) -> Router {
     Router::new()
+        .route(
+            "/api/user/send-code",
+            post(interface::user::send_verification_code),
+        )
+        .route("/api/user/register", post(interface::user::register))
         .route("/api/user/login", post(interface::user::login))
+        .route("/api/user/logout", post(interface::user::logout))
+        .route("/api/user/current", get(interface::user::current))
+        .route("/api/user/username", post(interface::user::update_username))
+        .route("/api/user/password", post(interface::user::update_password))
+        .route("/api/user/email", post(interface::user::update_email))
+        .route(
+            "/api/user/password-reset-code",
+            post(interface::user::password_reset_code),
+        )
+        .route(
+            "/api/user/password-reset",
+            post(interface::user::password_reset),
+        )
         .route("/api/user/avatar", post(interface::user::update_avatar))
         .with_state(state)
 }
@@ -352,6 +370,34 @@ fn multipart_body(boundary: &str, content_type: &str, bytes: &[u8]) -> Vec<u8> {
     body.extend_from_slice(bytes);
     body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
     body
+}
+
+fn json_request(method: &str, uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+async fn login_token(app: Router) -> String {
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/api/user/login",
+            json!({
+                "email": "alice",
+                "password": "password123"
+            }),
+        ))
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    body["data"]["token"]
+        .as_str()
+        .expect("login should produce token")
+        .to_string()
 }
 
 #[tokio::test]
@@ -385,6 +431,258 @@ async fn login_accepts_username_in_email_field() {
             .as_str()
             .is_some_and(|token| !token.is_empty())
     );
+}
+
+#[tokio::test]
+async fn registration_code_and_password_reset_use_debug_codes_without_smtp() {
+    let upload_dir = unique_upload_dir("code-flow");
+    let state = test_state(upload_dir, "");
+    let app = app(state.clone());
+
+    let send_response = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/user/send-code",
+            json!({ "email": "NewUser@Example.com" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(send_response.status(), StatusCode::OK);
+    let send_body = response_json(send_response).await;
+    let register_code = send_body["debugCode"].as_str().unwrap().to_string();
+
+    let register_response = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/user/register",
+            json!({
+                "email": "newuser@example.com",
+                "username": "new-user",
+                "password": "secret123",
+                "verificationCode": register_code
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(register_response.status(), StatusCode::OK);
+    let register_body = response_json(register_response).await;
+    assert_eq!(register_body["success"], true);
+    assert_eq!(register_body["data"]["email"], "newuser@example.com");
+    assert!(
+        state
+            .verification_codes
+            .read()
+            .await
+            .get("newuser@example.com")
+            .is_none()
+    );
+
+    let reset_code_response = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/user/password-reset-code",
+            json!({ "email": "alice@example.com" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(reset_code_response.status(), StatusCode::OK);
+    let reset_body = response_json(reset_code_response).await;
+    let reset_code = reset_body["debugCode"].as_str().unwrap().to_string();
+
+    let reset_response = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/user/password-reset",
+            json!({
+                "email": "alice@example.com",
+                "verificationCode": reset_code,
+                "newPassword": "new-password"
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(reset_response.status(), StatusCode::OK);
+    assert_eq!(response_json(reset_response).await["success"], true);
+
+    let login_response = app
+        .oneshot(json_request(
+            "POST",
+            "/api/user/login",
+            json!({
+                "email": "alice@example.com",
+                "password": "new-password"
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(login_response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn authenticated_profile_update_paths_cover_success_and_validation() {
+    let upload_dir = unique_upload_dir("profile-update");
+    let state = test_state(upload_dir, "/static/avatars/existing.png");
+    let app = app(state.clone());
+    let token = login_token(app.clone()).await;
+
+    let current_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/user/current")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(current_response.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(current_response).await["data"]["username"],
+        "alice"
+    );
+
+    let rename_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/user/username")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "username": "  alice-renamed  " }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rename_response.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(rename_response).await["data"]["username"],
+        "alice-renamed"
+    );
+
+    let wrong_password_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/user/password")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "currentPassword": "wrong", "newPassword": "new-password" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(wrong_password_response.status(), StatusCode::BAD_REQUEST);
+
+    let change_password_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/user/password")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "currentPassword": "password123", "newPassword": "new-password" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(change_password_response.status(), StatusCode::OK);
+
+    state.verification_codes.write().await.insert(
+        "updated@example.com".to_string(),
+        VerificationCodeRecord {
+            code: "654321".to_string(),
+            expires_at_unix: time::OffsetDateTime::now_utc().unix_timestamp() + 60,
+        },
+    );
+    let email_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/user/email")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "newEmail": "updated@example.com", "verificationCode": "654321" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(email_response.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(email_response).await["data"]["email"],
+        "updated@example.com"
+    );
+}
+
+#[tokio::test]
+async fn user_validation_paths_return_errors_before_mutating_state() {
+    let upload_dir = unique_upload_dir("validation");
+    let app = app(test_state(upload_dir, ""));
+
+    for (uri, body) in [
+        ("/api/user/send-code", json!({ "email": "not-an-email" })),
+        (
+            "/api/user/register",
+            json!({
+                "email": "valid@example.com",
+                "username": " ",
+                "password": "secret",
+                "verificationCode": "123456"
+            }),
+        ),
+        (
+            "/api/user/login",
+            json!({ "email": " ", "password": "secret" }),
+        ),
+        (
+            "/api/user/password-reset",
+            json!({
+                "email": "alice@example.com",
+                "verificationCode": " ",
+                "newPassword": "secret"
+            }),
+        ),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(json_request("POST", uri, body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response_json(response).await["success"], false);
+    }
+
+    let logout_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/user/logout")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(logout_response.status(), StatusCode::OK);
+    assert_eq!(response_json(logout_response).await["success"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add backend coverage-focused tests for user HTTP flows, verification codes, password reset, profile/email/password/avatar paths.
- Add coverage tests for rule market list/detail/developer/review/image upload paths and rule draft/admin/persistence branches.
- Add room lifecycle/game snapshot coverage through integration tests under `tests/` only, without production source changes.

## Coverage
- Baseline line coverage: 44.05%
- Previous PR line coverage: 57.14%
- Current line coverage: 75.24%
- `interface/room.rs`: 93.45% line coverage
- `interface/market.rs`: 70.52% line coverage
- `interface/rule.rs`: 77.73% line coverage
- `interface/user.rs`: 87.85% line coverage

## Test Plan
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo llvm-cov --workspace --all-targets --ignore-filename-regex '(^|/)src/(main|state|lib)\.rs' --summary-only

Closes #144
