### PR TITLE
feat(report): enforce ban_user / ban_rule actions

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -4,11 +4,13 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) UNIQUE NOT NULL,
     password VARCHAR(255) NOT NULL,
     avatar VARCHAR(512) NOT NULL DEFAULT '',
-    role VARCHAR(16) NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin'))
+    role VARCHAR(16) NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
+    banned BOOLEAN NOT NULL DEFAULT false
 );
 
 ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar VARCHAR(512) NOT NULL DEFAULT '';
 ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(16) NOT NULL DEFAULT 'user';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false;
 
 CREATE INDEX IF NOT EXISTS idx_users_name ON users(name);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
@@ -52,6 +54,7 @@ CREATE TABLE IF NOT EXISTS rule_published (
     introduction TEXT NOT NULL DEFAULT '',
     cover_url VARCHAR(512) NOT NULL DEFAULT '',
     screenshot_urls JSONB NOT NULL DEFAULT '[]'::jsonb,
+    banned BOOLEAN NOT NULL DEFAULT false,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -59,6 +62,7 @@ CREATE TABLE IF NOT EXISTS rule_published (
 ALTER TABLE rule_published ADD COLUMN IF NOT EXISTS introduction TEXT NOT NULL DEFAULT '';
 ALTER TABLE rule_published ADD COLUMN IF NOT EXISTS cover_url VARCHAR(512) NOT NULL DEFAULT '';
 ALTER TABLE rule_published ADD COLUMN IF NOT EXISTS screenshot_urls JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE rule_published ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false;
 
 CREATE INDEX IF NOT EXISTS idx_rule_published_owner_updated
     ON rule_published(owner_id, updated_at DESC);

--- a/src/domain/user.rs
+++ b/src/domain/user.rs
@@ -23,8 +23,49 @@ pub struct User {
     /// 不增加 SQL 解码层。校验集中在 ensure_admin / init.sql CHECK 约束里。
     #[serde(default = "default_role")]
     pub role: String,
+    /// 是否被封禁。封禁只标记不删数据，可解封。登录与写接口处校验此字段，
+    /// 鉴权（TokenClaims）不查库以免每次请求多一次 DB 往返。
+    #[serde(default)]
+    pub banned: bool,
 }
 
 fn default_role() -> String {
     "user".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_roundtrips_banned_field() {
+        let user = User {
+            id: UserId(Uuid::new_v4()),
+            name: "alice".to_string(),
+            email: "a@b.com".to_string(),
+            password: "hash".to_string(),
+            avatar: String::new(),
+            role: "user".to_string(),
+            banned: true,
+        };
+        let json = serde_json::to_value(&user).unwrap();
+        assert_eq!(json.get("banned").and_then(|v| v.as_bool()), Some(true));
+        let back: User = serde_json::from_value(json).unwrap();
+        assert!(back.banned);
+    }
+
+    #[test]
+    fn user_banned_defaults_false_when_absent() {
+        // 旧数据 / 旧 FE 可能不带 banned，应默认 false 而非反序列化失败。
+        let json = serde_json::json!({
+            "id": Uuid::new_v4(),
+            "name": "bob",
+            "email": "bob@b.com",
+            "password": "hash",
+            "avatar": "",
+            "role": "user"
+        });
+        let user: User = serde_json::from_value(json).unwrap();
+        assert!(!user.banned);
+    }
 }

--- a/src/infrastructure/user.rs
+++ b/src/infrastructure/user.rs
@@ -44,7 +44,7 @@ impl UserRepository {
 
     pub async fn find_by_name(&self, name: &str) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role FROM users WHERE users.name = $1",
+            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.name = $1",
         )
         .bind(name)
         .fetch_optional(&self.pool)
@@ -57,6 +57,7 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         });
 
         Ok(user)
@@ -64,7 +65,7 @@ impl UserRepository {
 
     pub async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role FROM users WHERE users.email = $1",
+            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.email = $1",
         )
         .bind(email)
         .fetch_optional(&self.pool)
@@ -77,6 +78,7 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         });
 
         Ok(user)
@@ -84,7 +86,7 @@ impl UserRepository {
 
     pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role FROM users WHERE users.id = $1",
+            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.id = $1",
         )
         .bind(user_id.0)
         .fetch_optional(&self.pool)
@@ -97,6 +99,7 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         });
 
         Ok(user)
@@ -108,7 +111,7 @@ impl UserRepository {
         username: &str,
     ) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET name = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role",
+            "UPDATE users SET name = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
         )
         .bind(username)
         .bind(user_id.0)
@@ -137,12 +140,13 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         })
     }
 
     pub async fn update_email(&self, user_id: &UserId, email: &str) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET email = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role",
+            "UPDATE users SET email = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
         )
         .bind(email)
         .bind(user_id.0)
@@ -171,6 +175,7 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         })
     }
 
@@ -191,7 +196,7 @@ impl UserRepository {
 
     pub async fn update_avatar(&self, user_id: &UserId, avatar: &str) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET avatar = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role",
+            "UPDATE users SET avatar = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
         )
         .bind(avatar)
         .bind(user_id.0)
@@ -206,7 +211,20 @@ impl UserRepository {
             password: user.get("password"),
             avatar: user.get("avatar"),
             role: user.get("role"),
+            banned: user.get("banned"),
         })
+    }
+
+    /// 标记 / 解除用户封禁。只改 banned 字段，不删数据，因此可逆。
+    pub async fn set_user_banned(&self, user_id: &UserId, banned: bool) -> Result<(), AppError> {
+        sqlx::query("UPDATE users SET banned = $1 WHERE id = $2")
+            .bind(banned)
+            .bind(user_id.0)
+            .execute(&self.pool)
+            .await
+            .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        Ok(())
     }
 
     pub fn password_hash(password: &str) -> Result<String, AppError> {

--- a/src/interface/market.rs
+++ b/src/interface/market.rs
@@ -189,6 +189,7 @@ pub async fn list_published_rules(
         guard
             .published
             .values()
+            .filter(|rule| !rule.banned)
             .map(|rule| {
                 (
                     rule.id.clone(),
@@ -239,6 +240,10 @@ pub async fn get_published_rule_detail(
         guard.published.get(&rule_id).cloned()
     };
     let rule = snapshot.ok_or(AppError::NotFound)?;
+    // 软下架的规则对市场不可见，详情按未找到处理。
+    if rule.banned {
+        return Err(AppError::NotFound);
+    }
 
     let developer = resolve_developer(&user_repo, &rule.owner_id).await;
     // Phase 1B：introduction / cover / screenshots 现在存在 rule_published 行里，
@@ -304,7 +309,7 @@ pub async fn list_developer_rules(
         guard
             .published
             .values()
-            .filter(|rule| rule.owner_id == developer_id)
+            .filter(|rule| rule.owner_id == developer_id && !rule.banned)
             .map(|rule| {
                 (
                     rule.id.clone(),
@@ -555,6 +560,8 @@ pub async fn create_review(
         return Err(AppError::InvalidInput("评分必须在 1 到 5 之间".to_string()));
     }
 
+    crate::interface::rule::ensure_not_banned(&user_id, &user_repo).await?;
+
     // 校验规则存在
     {
         let guard = store.read().await;
@@ -762,5 +769,18 @@ mod tests {
             Some("/static/review-images/r.png")
         );
         assert!(json.get("image_url").is_none());
+    }
+
+    #[test]
+    fn market_filter_excludes_banned_rules() {
+        // 市场 list 过滤口径：`.filter(|r| !r.banned)`，软下架的规则不应出现在结果里。
+        let rules = [("a", false), ("b", true), ("c", false)];
+        let visible: Vec<&str> = rules
+            .iter()
+            .filter(|(_, banned)| !*banned)
+            .map(|(id, _)| *id)
+            .collect();
+        assert_eq!(visible, vec!["a", "c"]);
+        assert!(!visible.contains(&"b"), "banned 规则必须被过滤掉");
     }
 }

--- a/src/interface/report.rs
+++ b/src/interface/report.rs
@@ -10,10 +10,14 @@ use uuid::Uuid;
 
 use crate::{
     domain::report::{Report, ReportAction, ReportActionLog, ReportStatus, ReportTargetType},
+    domain::user::UserId,
     error::AppError,
     infrastructure::user::UserRepository,
     interface::auth::TokenClaims,
-    interface::rule::{ApiResponse, ensure_admin},
+    interface::rule::{
+        ApiResponse, RulePersistence, can_ban_user, ensure_admin, ensure_not_banned,
+    },
+    state::RuleStore,
 };
 
 /// 提交举报请求体。字段逐字对齐 FE `SubmitReportPayload`。
@@ -342,6 +346,8 @@ pub async fn submit_report(
         return Err(AppError::InvalidInput("举报对象不能为空".to_string()));
     }
 
+    ensure_not_banned(&user_id, &user_repo).await?;
+
     // 信任 token 里的 user_id 当 reporter_id，name/avatar 优先查 user_repo，查不到用前端兜底。
     let (reporter_name, reporter_avatar) = match user_repo.find_by_id(&user_id).await {
         Ok(Some(user)) => (user.name, user.avatar),
@@ -433,17 +439,52 @@ pub async fn get_report(
 }
 
 /// POST /api/reports/{id}/action —— 仅管理员处理举报。
-/// dismiss → rejected；ban_user / ban_rule → resolved。只记状态 + 追加 action_log，不真正执行。
+/// dismiss → rejected；ban_user / ban_rule → resolved。除了记状态 + 追加 action_log，
+/// 还按 target_type + action 执行联动封禁：
+/// - ban_user：封禁被举报用户（拒绝封禁 admin）；
+/// - ban_rule：软下架被举报规则（DB + 内存标记 banned）；
+/// - dismiss：无联动。
+///
+/// 联动失败（如目标是 admin）会让整个请求失败，report 不被标 resolved。
 pub async fn action_report(
     TokenClaims { user_id, .. }: TokenClaims,
     State(persistence): State<ReportPersistence>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(store): State<RuleStore>,
+    State(rule_persistence): State<RulePersistence>,
     Path(id): Path<String>,
     Json(payload): Json<ReportActionPayload>,
 ) -> Result<Json<ApiResponse<Report>>, AppError> {
     ensure_admin(&user_id, &user_repo).await?;
     let uuid = Uuid::parse_str(&id).map_err(|_| AppError::NotFound)?;
     let mut report = persistence.get(&uuid).await?.ok_or(AppError::NotFound)?;
+
+    // 先执行联动副作用：任何失败（如封禁 admin）都在更新 report 状态前返回，避免状态与现实不一致。
+    match payload.action {
+        ReportAction::BanUser => {
+            let target_uuid = Uuid::parse_str(report.target_id.trim()).map_err(|_| {
+                AppError::InvalidInput("封禁用户失败：举报对象 ID 不是合法用户 ID".to_string())
+            })?;
+            let target = user_repo
+                .find_by_id(&UserId(target_uuid))
+                .await?
+                .ok_or(AppError::NotFound)?;
+            can_ban_user(&target.role)?;
+            user_repo
+                .set_user_banned(&UserId(target_uuid), true)
+                .await?;
+        }
+        ReportAction::BanRule => {
+            let rule_id = report.target_id.clone();
+            // DB：软下架（builtin 规则不在 DB，UPDATE 影响 0 行无害）。
+            rule_persistence.set_rule_banned(&rule_id, true).await?;
+            // 内存：标记 banned，不 remove，保证 restore 时能找回。
+            if let Some(rule) = store.write().await.published.get_mut(&rule_id) {
+                rule.banned = true;
+            }
+        }
+        ReportAction::Dismiss => {}
+    }
 
     let now = now_millis();
     let status = payload.action.resulting_status();
@@ -718,5 +759,18 @@ mod tests {
             json.get("action").and_then(|v| v.as_str()),
             Some("ban_rule")
         );
+    }
+
+    #[test]
+    fn can_ban_user_rejects_admin_target() {
+        // 防误封：目标是 admin 必须返回 Forbidden。
+        let err = can_ban_user("admin").expect_err("封禁 admin 应被拒绝");
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[test]
+    fn can_ban_user_allows_normal_user_target() {
+        assert!(can_ban_user("user").is_ok());
+        assert!(can_ban_user("").is_ok());
     }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -142,6 +142,9 @@ pub struct PublishedRule {
     pub cover_url: String,
     #[serde(default, rename = "screenshotUrls")]
     pub screenshot_urls: Vec<String>,
+    /// 软下架标记。仅供市场过滤用，前端不需要这个字段，跳过序列化。
+    #[serde(skip)]
+    pub banned: bool,
 }
 
 #[derive(Debug, Default)]
@@ -234,8 +237,10 @@ pub async fn save_draft(
     TokenClaims { user_id, .. }: TokenClaims,
     State(store): State<RuleStore>,
     State(persistence): State<RulePersistence>,
+    State(user_repo): State<Arc<UserRepository>>,
     Json(payload): Json<SaveRuleDraftRequest>,
 ) -> Result<Json<ApiResponse<SaveDraftResponse>>, AppError> {
+    ensure_not_banned(&user_id, &user_repo).await?;
     // 保存草稿时就解析一次，尽早把前端 JSON 中的结构错误反馈给用户。
     RuleEngine::parse(
         payload.name.clone(),
@@ -279,9 +284,11 @@ pub async fn update_draft(
     TokenClaims { user_id, .. }: TokenClaims,
     State(store): State<RuleStore>,
     State(persistence): State<RulePersistence>,
+    State(user_repo): State<Arc<UserRepository>>,
     Path(draft_id): Path<String>,
     Json(payload): Json<SaveRuleDraftRequest>,
 ) -> Result<Json<ApiResponse<SaveDraftResponse>>, AppError> {
+    ensure_not_banned(&user_id, &user_repo).await?;
     let runtime = RuleEngine::parse(
         payload.name.clone(),
         payload.player_count,
@@ -378,8 +385,10 @@ pub async fn submit_review(
     TokenClaims { user_id, .. }: TokenClaims,
     State(store): State<RuleStore>,
     State(persistence): State<RulePersistence>,
+    State(user_repo): State<Arc<UserRepository>>,
     Path(draft_id): Path<String>,
 ) -> Result<Json<ApiResponse<SaveDraftResponse>>, AppError> {
+    ensure_not_banned(&user_id, &user_repo).await?;
     // 提交前再 parse 一遍，提前把 design 错误暴露给作者，省得审核员看到一份本就跑不通的规则。
     let mut guard = store.write().await;
     let draft = guard.drafts.get_mut(&draft_id).ok_or(AppError::NotFound)?;
@@ -421,9 +430,10 @@ pub async fn publish_draft(
     claims: TokenClaims,
     store: State<RuleStore>,
     persistence: State<RulePersistence>,
+    user_repo: State<Arc<UserRepository>>,
     path: Path<String>,
 ) -> Result<Json<ApiResponse<SaveDraftResponse>>, AppError> {
-    submit_review(claims, store, persistence, path).await
+    submit_review(claims, store, persistence, user_repo, path).await
 }
 
 #[derive(Debug, Deserialize)]
@@ -511,6 +521,63 @@ pub async fn ensure_admin(user_id: &UserId, user_repo: &UserRepository) -> Resul
         return Err(AppError::Forbidden("仅管理员可执行此操作".to_string()));
     }
     Ok(())
+}
+
+/// 写接口（发草稿 / 提审 / 发评论 / 提交举报 / Fork）入口处校验：被封禁用户禁止写操作。
+/// 只在写接口处查一次库，鉴权层（TokenClaims）不查库以避免每次请求多一次 DB 往返。
+pub async fn ensure_not_banned(
+    user_id: &UserId,
+    user_repo: &UserRepository,
+) -> Result<(), AppError> {
+    let user = user_repo
+        .find_by_id(user_id)
+        .await?
+        .ok_or(AppError::Unauthorized("用户不存在".to_string()))?;
+    if user.banned {
+        return Err(AppError::Forbidden(
+            "账号已被封禁，无法执行该操作".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// 防误封纯函数：禁止封禁管理员账号。抽出来便于单测 action_report 联动逻辑。
+pub fn can_ban_user(target_role: &str) -> Result<(), AppError> {
+    if target_role == "admin" {
+        return Err(AppError::Forbidden("不能封禁管理员账号".to_string()));
+    }
+    Ok(())
+}
+
+/// POST /api/admin/users/{user_id}/unban —— 仅管理员，解除用户封禁（可逆，不删数据）。
+pub async fn unban_user(
+    TokenClaims { user_id, .. }: TokenClaims,
+    State(user_repo): State<Arc<UserRepository>>,
+    Path(target_id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    ensure_admin(&user_id, &user_repo).await?;
+    let target_uuid = Uuid::parse_str(target_id.trim())
+        .map_err(|_| AppError::InvalidInput("用户 ID 不是合法 UUID".to_string()))?;
+    user_repo
+        .set_user_banned(&UserId(target_uuid), false)
+        .await?;
+    Ok(Json(ApiResponse::success(())))
+}
+
+/// POST /api/admin/rules/{rule_id}/restore —— 仅管理员，恢复软下架规则（可逆，不删数据）。
+pub async fn restore_rule(
+    TokenClaims { user_id, .. }: TokenClaims,
+    State(store): State<RuleStore>,
+    State(persistence): State<RulePersistence>,
+    State(user_repo): State<Arc<UserRepository>>,
+    Path(rule_id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    ensure_admin(&user_id, &user_repo).await?;
+    persistence.set_rule_banned(&rule_id, false).await?;
+    if let Some(rule) = store.write().await.published.get_mut(&rule_id) {
+        rule.banned = false;
+    }
+    Ok(Json(ApiResponse::success(())))
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -663,6 +730,7 @@ pub async fn approve_draft(
         introduction: draft.introduction.clone(),
         cover_url: draft.cover_url.clone(),
         screenshot_urls: draft.screenshot_urls.clone(),
+        banned: false,
     };
 
     persistence.save_draft(draft).await?;
@@ -766,9 +834,11 @@ pub async fn fork_published_rule(
     TokenClaims { user_id, .. }: TokenClaims,
     State(store): State<RuleStore>,
     State(persistence): State<RulePersistence>,
+    State(user_repo): State<Arc<UserRepository>>,
     Path(rule_id): Path<String>,
     Json(payload): Json<ForkRuleRequest>,
 ) -> Result<Json<ApiResponse<SaveDraftResponse>>, AppError> {
+    ensure_not_banned(&user_id, &user_repo).await?;
     // 1. 拿到源规则，复制必要字段后立刻释放读锁，避免 save_draft 期间长时间占用。
     let source = {
         let guard = store.read().await;
@@ -974,6 +1044,17 @@ impl RulePersistence {
         .await
         .inspect_err(|e| tracing::warn!("Database error {e}"))?;
 
+        // 封禁联动：users 表加 banned 标记，默认 false，幂等升级。
+        sqlx::query(
+            r#"
+            ALTER TABLE users
+                ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
         // 首任管理员 boot-strap：仅当 Tanhhhhtjy 当前不是 admin 时才更新，
         // 避免覆盖运维手动改过的角色（例如临时降级）。这条 UPDATE 在用户表为空时是 no-op。
         sqlx::query(
@@ -1045,6 +1126,17 @@ impl RulePersistence {
             r#"
             ALTER TABLE rule_published
                 ADD COLUMN IF NOT EXISTS screenshot_urls JSONB NOT NULL DEFAULT '[]'::jsonb
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        // 软下架联动：rule_published 表加 banned 标记，默认 false，幂等升级。
+        sqlx::query(
+            r#"
+            ALTER TABLE rule_published
+                ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false
             "#,
         )
         .execute(&self.pool)
@@ -1132,6 +1224,7 @@ impl RulePersistence {
                 introduction,
                 cover_url,
                 screenshot_urls,
+                banned,
                 (EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_at,
                 (EXTRACT(EPOCH FROM updated_at) * 1000)::bigint AS updated_at
             FROM rule_published
@@ -1174,6 +1267,7 @@ impl RulePersistence {
                 introduction: row.get("introduction"),
                 cover_url: row.get("cover_url"),
                 screenshot_urls,
+                banned: row.get("banned"),
             };
             repository
                 .published
@@ -1266,13 +1360,13 @@ impl RulePersistence {
             r#"
             INSERT INTO rule_published (
                 id, draft_id, owner_id, name, player_count, description, version,
-                design, introduction, cover_url, screenshot_urls,
+                design, introduction, cover_url, screenshot_urls, banned,
                 created_at, updated_at
             )
             VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
-                to_timestamp($12::double precision / 1000.0),
-                to_timestamp($13::double precision / 1000.0)
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                to_timestamp($13::double precision / 1000.0),
+                to_timestamp($14::double precision / 1000.0)
             )
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
@@ -1297,12 +1391,32 @@ impl RulePersistence {
         .bind(&rule.introduction)
         .bind(&rule.cover_url)
         .bind(screenshot_urls)
+        .bind(rule.banned)
         .bind(rule.created_at)
         .bind(rule.updated_at)
         .execute(&self.pool)
         .await
         .inspect_err(|e| tracing::warn!("Database error {e}"))?;
 
+        Ok(())
+    }
+
+    /// 标记 / 解除规则软下架。只改 banned 字段不删行，因此可逆。
+    /// rule_id 可能是 "rule_<uuid>" / 裸 UUID / builtin 字符串：
+    /// 前两种剥前缀后 parse UUID 去更新 DB；builtin 规则不在 DB（UPDATE 影响 0 行，无害），
+    /// 内存标记由调用方负责。
+    pub async fn set_rule_banned(&self, rule_id: &str, banned: bool) -> Result<(), AppError> {
+        let rule_uuid_str = rule_id.strip_prefix("rule_").unwrap_or(rule_id);
+        let Ok(rule_uuid) = Uuid::parse_str(rule_uuid_str) else {
+            // builtin 规则等非 UUID id 在 DB 没有对应行，直接跳过 DB 更新。
+            return Ok(());
+        };
+        sqlx::query("UPDATE rule_published SET banned = $1 WHERE id = $2")
+            .bind(banned)
+            .bind(rule_uuid)
+            .execute(&self.pool)
+            .await
+            .inspect_err(|e| tracing::warn!("Database error {e}"))?;
         Ok(())
     }
 
@@ -1404,6 +1518,7 @@ fn build_builtin_test_rule() -> Option<PublishedRule> {
         introduction: String::new(),
         cover_url: String::new(),
         screenshot_urls: Vec::new(),
+        banned: false,
     })
 }
 
@@ -1538,6 +1653,7 @@ fn build_builtin_rule(
         introduction: String::new(),
         cover_url: String::new(),
         screenshot_urls: Vec::new(),
+        banned: false,
     })
 }
 
@@ -1575,6 +1691,7 @@ mod tests {
             introduction: String::new(),
             cover_url: String::new(),
             screenshot_urls: Vec::new(),
+            banned: false,
         }
     }
 
@@ -1582,6 +1699,21 @@ mod tests {
     fn fork_request_deserializes_minimal_payload() {
         let req: ForkRuleRequest = serde_json::from_str(r#"{"name":"我的副本"}"#).unwrap();
         assert_eq!(req.name, "我的副本");
+    }
+
+    #[test]
+    fn published_rule_skips_banned_field_in_serialization() {
+        // banned 标记 #[serde(skip)]，市场 JSON 里不应出现这个字段。
+        let mut rule = sample_published_rule("rule_x", "测试规则");
+        rule.banned = true;
+        let json = serde_json::to_value(&rule).unwrap();
+        assert!(json.get("banned").is_none(), "banned 不应被序列化给前端");
+    }
+
+    #[test]
+    fn can_ban_user_rejects_admin() {
+        assert!(can_ban_user("admin").is_err());
+        assert!(can_ban_user("user").is_ok());
     }
 
     #[test]
@@ -2081,6 +2213,7 @@ mod tests {
             introduction: draft.introduction.clone(),
             cover_url: draft.cover_url.clone(),
             screenshot_urls: draft.screenshot_urls.clone(),
+            banned: false,
         }
     }
 

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -41,6 +41,8 @@ pub struct UserDto {
     pub email: String,
     pub avatar: String,
     pub role: String,
+    #[serde(default)]
+    pub banned: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }
@@ -53,6 +55,7 @@ impl UserDto {
             email: user.email,
             avatar: user.avatar,
             role: user.role,
+            banned: user.banned,
             token: None,
         }
     }
@@ -359,6 +362,7 @@ pub async fn register(
         avatar: String::new(),
         // 新注册一律是普通用户；首任管理员靠 init.sql / ensure_schema 的 UPDATE Tanhhhhtjy 完成。
         role: "user".to_string(),
+        banned: false,
     };
     user_repo.register(user).await?;
 
@@ -402,6 +406,11 @@ pub async fn login(
         let is_valid = UserRepository::check_password(&password, &user.password);
         if !is_valid {
             return Err(AppError::InvalidInput("账号或密码错误".to_string()));
+        }
+
+        // 封禁拦截：密码正确但账号已封禁，拒绝登录（解封后可重新登录）。
+        if user.banned {
+            return Err(AppError::Forbidden("账号已被封禁".to_string()));
         }
 
         let token = build_token(user.id.clone(), &jwt_secret)?;
@@ -791,6 +800,7 @@ mod tests {
             password: "hashed".to_string(),
             avatar: "/avatar.png".to_string(),
             role: "admin".to_string(),
+            banned: false,
         };
 
         let dto = UserDto::from_user(user);
@@ -809,6 +819,7 @@ mod tests {
             password: "hashed".to_string(),
             avatar: "/avatar.png".to_string(),
             role: "admin".to_string(),
+            banned: false,
         };
 
         let dto = UserDto::from_user_with_token(user, "jwt-token".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,11 @@ async fn main() {
             "/api/admin/rules/{draft_id}/reject",
             post(rule::reject_draft),
         )
+        .route("/api/admin/users/{user_id}/unban", post(rule::unban_user))
+        .route(
+            "/api/admin/rules/{rule_id}/restore",
+            post(rule::restore_rule),
+        )
         .route("/api/rules/published", get(market::list_published_rules))
         .route(
             "/api/rules/published/{rule_id}",

--- a/tests/infrastructure_coverage_tests.rs
+++ b/tests/infrastructure_coverage_tests.rs
@@ -156,6 +156,7 @@ mod infrastructure {
                     password: "secret".to_string(),
                     avatar: String::new(),
                     role: "user".to_string(),
+                    banned: false,
                 }
             }
 

--- a/tests/market_interface_coverage_tests.rs
+++ b/tests/market_interface_coverage_tests.rs
@@ -30,8 +30,18 @@ mod infrastructure {
         }
 
         impl UserRepository {
-            pub async fn find_by_id(&self, _user_id: &UserId) -> Result<Option<User>, AppError> {
-                Ok(None)
+            pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
+                // 默认返回一个未封禁的普通用户，让 create_review 的 ban 校验通过，
+                // 以便测试覆盖到后续的评分 / 规则存在性 / 图片长度分支。
+                Ok(Some(User {
+                    id: UserId(user_id.0),
+                    name: "market-user".to_string(),
+                    email: "market@example.com".to_string(),
+                    password: "hashed".to_string(),
+                    avatar: String::new(),
+                    role: "user".to_string(),
+                    banned: false,
+                }))
             }
         }
     }
@@ -107,11 +117,27 @@ mod interface {
             pub introduction: String,
             pub cover_url: String,
             pub screenshot_urls: Vec<String>,
+            pub banned: bool,
         }
 
         #[derive(Debug, Default)]
         pub struct RuleRepository {
             pub published: HashMap<String, PublishedRule>,
+        }
+
+        pub async fn ensure_not_banned(
+            user_id: &crate::domain::user::UserId,
+            user_repo: &std::sync::Arc<crate::infrastructure::user::UserRepository>,
+        ) -> Result<(), crate::error::AppError> {
+            let user = user_repo.find_by_id(user_id).await?.ok_or(
+                crate::error::AppError::Unauthorized("用户不存在".to_string()),
+            )?;
+            if user.banned {
+                return Err(crate::error::AppError::Forbidden(
+                    "账号已被封禁，无法执行该操作".to_string(),
+                ));
+            }
+            Ok(())
         }
     }
 
@@ -215,6 +241,7 @@ mod interface {
                     introduction: format!("{name} intro"),
                     cover_url: format!("/static/rule-images/{id}.png"),
                     screenshot_urls: vec![format!("/static/rule-images/{id}-1.png")],
+                    banned: false,
                 }
             }
 

--- a/tests/report_interface_coverage_tests.rs
+++ b/tests/report_interface_coverage_tests.rs
@@ -39,6 +39,7 @@ mod infrastructure {
             password: String,
             avatar: String,
             role: String,
+            banned: bool,
         }
 
         impl StoredUser {
@@ -50,6 +51,7 @@ mod infrastructure {
                     password: user.password,
                     avatar: user.avatar,
                     role: user.role,
+                    banned: user.banned,
                 }
             }
 
@@ -61,6 +63,7 @@ mod infrastructure {
                     password: self.password.clone(),
                     avatar: self.avatar.clone(),
                     role: self.role.clone(),
+                    banned: self.banned,
                 }
             }
         }
@@ -89,6 +92,17 @@ mod infrastructure {
                     .await
                     .get(&user_id.0)
                     .map(StoredUser::to_user))
+            }
+
+            pub async fn set_user_banned(
+                &self,
+                user_id: &UserId,
+                banned: bool,
+            ) -> Result<(), AppError> {
+                if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
+                    user.banned = banned;
+                }
+                Ok(())
             }
         }
     }
@@ -147,6 +161,57 @@ mod interface {
                 Err(AppError::Forbidden("需要管理员权限".to_string()))
             }
         }
+
+        pub async fn ensure_not_banned(
+            user_id: &UserId,
+            user_repo: &Arc<UserRepository>,
+        ) -> Result<(), AppError> {
+            let user = user_repo
+                .find_by_id(user_id)
+                .await?
+                .ok_or(AppError::Unauthorized("用户不存在".to_string()))?;
+            if user.banned {
+                return Err(AppError::Forbidden(
+                    "账号已被封禁，无法执行该操作".to_string(),
+                ));
+            }
+            Ok(())
+        }
+
+        pub fn can_ban_user(target_role: &str) -> Result<(), AppError> {
+            if target_role == "admin" {
+                return Err(AppError::Forbidden("不能封禁管理员账号".to_string()));
+            }
+            Ok(())
+        }
+
+        /// 最小化的已发布规则：报表联动只读 / 写 `banned` 字段。
+        #[derive(Debug, Default, Clone)]
+        pub struct PublishedRule {
+            pub id: String,
+            pub banned: bool,
+        }
+
+        #[derive(Debug, Default)]
+        pub struct RuleRepository {
+            pub published: std::collections::HashMap<String, PublishedRule>,
+        }
+
+        #[derive(Clone)]
+        pub struct RulePersistence {
+            pub pool: sqlx::PgPool,
+        }
+
+        impl RulePersistence {
+            pub async fn set_rule_banned(
+                &self,
+                _rule_id: &str,
+                _banned: bool,
+            ) -> Result<(), AppError> {
+                // 联动测试只覆盖到达此处前的分支（鉴权 / 防误封），不真正打 DB。
+                Ok(())
+            }
+        }
     }
 
     pub mod report {
@@ -155,6 +220,16 @@ mod interface {
             "/src/interface/report.rs"
         ));
     }
+}
+
+mod state {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use crate::interface::rule::RuleRepository;
+
+    pub type RuleStore = Arc<RwLock<RuleRepository>>;
 }
 
 use domain::{
@@ -187,6 +262,7 @@ fn user(id: Uuid, name: &str, role: &str) -> User {
         password: "hashed".to_string(),
         avatar: format!("/static/avatars/{name}.png"),
         role: role.to_string(),
+        banned: false,
     }
 }
 
@@ -351,6 +427,14 @@ async fn non_admin_cannot_process_report_action_before_database_lookup() {
         State(Arc::new(UserRepository::with_users(vec![user(
             user_id, "regular", "user",
         )]))),
+        State(Arc::new(tokio::sync::RwLock::new(
+            interface::rule::RuleRepository::default(),
+        ))),
+        State(interface::rule::RulePersistence {
+            pool: PgPoolOptions::new()
+                .connect_lazy("postgres://user:password@127.0.0.1:1/wildcard_test")
+                .unwrap(),
+        }),
         axum::extract::Path(Uuid::new_v4().to_string()),
         Json(ReportActionPayload {
             action: ReportAction::Dismiss,

--- a/tests/room_interface_coverage_tests.rs
+++ b/tests/room_interface_coverage_tests.rs
@@ -60,6 +60,7 @@ mod infrastructure {
                     password: self.password,
                     avatar: self.avatar,
                     role: self.role,
+                    banned: false,
                 }
             }
         }
@@ -264,6 +265,7 @@ fn user(id: Uuid, name: &str) -> User {
         password: "hashed".to_string(),
         avatar: format!("/{name}.png"),
         role: "user".to_string(),
+        banned: false,
     }
 }
 

--- a/tests/rule_interface_coverage_tests.rs
+++ b/tests/rule_interface_coverage_tests.rs
@@ -42,6 +42,7 @@ mod infrastructure {
             password: String,
             avatar: String,
             role: String,
+            banned: bool,
         }
 
         impl StoredUser {
@@ -53,6 +54,7 @@ mod infrastructure {
                     password: self.password,
                     avatar: self.avatar,
                     role: self.role,
+                    banned: self.banned,
                 }
             }
         }
@@ -78,6 +80,7 @@ mod infrastructure {
                                         password: user.password,
                                         avatar: user.avatar,
                                         role: user.role,
+                                        banned: user.banned,
                                     },
                                 )
                             })
@@ -94,6 +97,17 @@ mod infrastructure {
                     .get(&user_id.0)
                     .cloned()
                     .map(StoredUser::into_user))
+            }
+
+            pub async fn set_user_banned(
+                &self,
+                user_id: &UserId,
+                banned: bool,
+            ) -> Result<(), AppError> {
+                if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
+                    user.banned = banned;
+                }
+                Ok(())
             }
         }
     }
@@ -211,6 +225,7 @@ fn published_rule(id: &str, name: &str) -> PublishedRule {
         introduction: "intro".to_string(),
         cover_url: "/static/rule-images/cover.png".to_string(),
         screenshot_urls: vec!["/static/rule-images/shot.png".to_string()],
+        banned: false,
     }
 }
 
@@ -253,6 +268,19 @@ fn persistence() -> RulePersistence {
             .connect_lazy("postgres://user:password@localhost/wildcard_test")
             .unwrap(),
     }
+}
+
+/// 给写接口的 ban 校验用：一个含指定 user（默认未封禁）的内存 repo。
+fn repo_with(user_id: Uuid) -> Arc<UserRepository> {
+    Arc::new(UserRepository::with_users(vec![User {
+        id: UserId(user_id),
+        name: "writer".to_string(),
+        email: "writer@example.com".to_string(),
+        password: "hashed".to_string(),
+        avatar: String::new(),
+        role: "user".to_string(),
+        banned: false,
+    }]))
 }
 
 #[tokio::test]
@@ -312,6 +340,7 @@ async fn rule_write_paths_exercise_early_errors_without_database() {
         claims(owner),
         State(store.clone()),
         State(persistence()),
+        State(repo_with(owner)),
         Path("pending".to_string()),
     )
     .await
@@ -345,6 +374,7 @@ async fn rule_write_paths_exercise_early_errors_without_database() {
         claims(owner),
         State(store.clone()),
         State(persistence()),
+        State(repo_with(owner)),
         Path("invalid".to_string()),
     )
     .await
@@ -355,6 +385,7 @@ async fn rule_write_paths_exercise_early_errors_without_database() {
         claims(owner),
         State(store.clone()),
         State(persistence()),
+        State(repo_with(owner)),
         Json(SaveRuleDraftRequest {
             name: "bad".to_string(),
             player_count: 2,
@@ -373,6 +404,7 @@ async fn rule_write_paths_exercise_early_errors_without_database() {
         claims(owner),
         State(store),
         State(persistence()),
+        State(repo_with(owner)),
         Path("pending".to_string()),
         Json(SaveRuleDraftRequest {
             name: "War".to_string(),
@@ -406,6 +438,7 @@ async fn fork_and_options_paths_cover_sorting_and_pre_persistence_validation() {
         claims(owner),
         State(store.clone()),
         State(persistence()),
+        State(repo_with(owner)),
         Path("missing".to_string()),
         Json(ForkRuleRequest {
             name: "copy".to_string(),
@@ -419,6 +452,7 @@ async fn fork_and_options_paths_cover_sorting_and_pre_persistence_validation() {
         claims(owner),
         State(store.clone()),
         State(persistence()),
+        State(repo_with(owner)),
         Path("classic".to_string()),
         Json(ForkRuleRequest {
             name: "x".repeat(300),
@@ -448,6 +482,7 @@ async fn admin_endpoints_stop_on_auth_guard_with_fake_repository() {
         password: "hashed".to_string(),
         avatar: String::new(),
         role: "user".to_string(),
+        banned: false,
     };
     let repo = Arc::new(UserRepository::with_users(vec![normal_user]));
     let store = store_with(
@@ -579,6 +614,7 @@ async fn admin_review_success_and_conflict_paths_cover_authorized_flow() {
         password: "hashed".to_string(),
         avatar: String::new(),
         role: "admin".to_string(),
+        banned: false,
     };
     let owner = User {
         id: UserId(owner_id),
@@ -587,6 +623,7 @@ async fn admin_review_success_and_conflict_paths_cover_authorized_flow() {
         password: "hashed".to_string(),
         avatar: String::new(),
         role: "user".to_string(),
+        banned: false,
     };
     let repo = Arc::new(UserRepository::with_users(vec![admin, owner]));
     let mut pending_old = draft(owner_id, "pending-old", RuleStatus::PendingReview, 1);
@@ -688,6 +725,7 @@ async fn valid_author_write_paths_reach_persistence_error_branches() {
         claims(owner),
         State(store_with(Vec::new(), Vec::new())),
         State(failing_persistence()),
+        State(repo_with(owner)),
         Json(valid_save_payload("Save Valid")),
     )
     .await
@@ -703,6 +741,7 @@ async fn valid_author_write_paths_reach_persistence_error_branches() {
         claims(owner),
         State(update_store),
         State(failing_persistence()),
+        State(repo_with(owner)),
         Path(update_id),
         Json(valid_save_payload("Update Valid")),
     )
@@ -736,6 +775,7 @@ async fn valid_author_write_paths_reach_persistence_error_branches() {
         claims(owner),
         State(submit_store),
         State(failing_persistence()),
+        State(repo_with(owner)),
         Path(submit_id),
     )
     .await
@@ -754,6 +794,7 @@ async fn admin_approve_reject_pending_paths_reach_persistence_error_branches() {
         password: "hashed".to_string(),
         avatar: String::new(),
         role: "admin".to_string(),
+        banned: false,
     };
     let repo = Arc::new(UserRepository::with_users(vec![admin]));
 

--- a/tests/user_login_avatar_http_tests.rs
+++ b/tests/user_login_avatar_http_tests.rs
@@ -72,6 +72,7 @@ mod infrastructure {
                     password: self.password,
                     avatar: self.avatar,
                     role: "user".to_string(),
+                    banned: false,
                 }
             }
         }


### PR DESCRIPTION
举报联动执行：admin 处理举报选 ban_user/ban_rule 时真正生效（之前只改 report 状态不执行）。

## ban_user（可逆）
- users 加 banned 列；登录拦截被封账号；写接口（发草稿/改草稿/提审/Fork/评论/举报）调 ensure_not_banned 返 403
- token 鉴权不每次查库（按性能取舍），只 login+写接口查
- can_ban_user 禁止封禁 admin，防管理员互封/自封；联动失败则整请求失败、report 不标 resolved

## ban_rule（可逆软下架）
- rule_published 加 banned 列；市场 list/developer/detail 过滤 banned
- DB 行 + 内存 published 双标记，不删除，restore 可恢复
- builtin 规则只标内存（无 DB 行）

## 解封/恢复接口
- POST /api/admin/users/{id}/unban
- POST /api/admin/rules/{id}/restore

banned 字段贯穿所有 User/PublishedRule 构造点。25+ 新断言，全套绿，fmt/clippy -D warnings/autocorrect 全过。