### PR TITLE
test: cover report enforcement guards

### DIFF
--- a/tests/market_interface_coverage_tests.rs
+++ b/tests/market_interface_coverage_tests.rs
@@ -510,7 +510,9 @@ mod interface {
                 .await
                 .unwrap_err();
 
-                assert!(matches!(err, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+                assert!(
+                    matches!(err, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作")
+                );
             }
         }
     }

--- a/tests/market_interface_coverage_tests.rs
+++ b/tests/market_interface_coverage_tests.rs
@@ -27,9 +27,27 @@ mod infrastructure {
         #[derive(Debug)]
         pub struct UserRepository {
             pub pool: PgPool,
+            pub role: String,
+            pub banned: bool,
         }
 
         impl UserRepository {
+            pub fn regular(pool: PgPool) -> Self {
+                Self {
+                    pool,
+                    role: "user".to_string(),
+                    banned: false,
+                }
+            }
+
+            pub fn banned(pool: PgPool) -> Self {
+                Self {
+                    pool,
+                    role: "user".to_string(),
+                    banned: true,
+                }
+            }
+
             pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
                 // 默认返回一个未封禁的普通用户，让 create_review 的 ban 校验通过，
                 // 以便测试覆盖到后续的评分 / 规则存在性 / 图片长度分支。
@@ -39,8 +57,8 @@ mod infrastructure {
                     email: "market@example.com".to_string(),
                     password: "hashed".to_string(),
                     avatar: String::new(),
-                    role: "user".to_string(),
-                    banned: false,
+                    role: self.role.clone(),
+                    banned: self.banned,
                 }))
             }
         }
@@ -269,7 +287,7 @@ mod interface {
             #[tokio::test]
             async fn list_detail_and_developer_paths_cover_filters_and_db_fallbacks() {
                 let pool = lazy_pool();
-                let user_repo = Arc::new(UserRepository { pool: pool.clone() });
+                let user_repo = Arc::new(UserRepository::regular(pool.clone()));
                 let persistence = RulePersistence { pool };
                 let store = store_with(vec![
                     published_rule("builtin-alpha", "builtin-owner", "Alpha", 10),
@@ -341,7 +359,7 @@ mod interface {
             #[tokio::test]
             async fn review_validation_and_upload_image_paths_cover_new_market_features() {
                 let pool = lazy_pool();
-                let user_repo = Arc::new(UserRepository { pool: pool.clone() });
+                let user_repo = Arc::new(UserRepository::regular(pool.clone()));
                 let persistence = RulePersistence { pool };
                 let store = store_with(vec![published_rule(
                     "builtin-alpha",
@@ -463,6 +481,36 @@ mod interface {
                     .unwrap();
                 assert_eq!(bad_response.status(), StatusCode::BAD_REQUEST);
                 tokio::fs::remove_dir_all(upload_root).await.unwrap();
+            }
+
+            #[tokio::test]
+            async fn banned_user_cannot_create_review_before_database_lookup() {
+                let pool = lazy_pool();
+                let user_repo = Arc::new(UserRepository::banned(pool.clone()));
+                let persistence = RulePersistence { pool };
+                let store = store_with(vec![published_rule(
+                    "builtin-alpha",
+                    "builtin-owner",
+                    "Alpha",
+                    10,
+                )]);
+
+                let err = create_review(
+                    claims(),
+                    State(user_repo),
+                    State(persistence),
+                    State(store),
+                    Path("builtin-alpha".to_string()),
+                    Json(CreateReviewRequest {
+                        rating: 5,
+                        content: "ok".to_string(),
+                        image_url: None,
+                    }),
+                )
+                .await
+                .unwrap_err();
+
+                assert!(matches!(err, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
             }
         }
     }

--- a/tests/rule_interface_coverage_tests.rs
+++ b/tests/rule_interface_coverage_tests.rs
@@ -272,14 +272,18 @@ fn persistence() -> RulePersistence {
 
 /// 给写接口的 ban 校验用：一个含指定 user（默认未封禁）的内存 repo。
 fn repo_with(user_id: Uuid) -> Arc<UserRepository> {
+    repo_with_state(user_id, "user", false)
+}
+
+fn repo_with_state(user_id: Uuid, role: &str, banned: bool) -> Arc<UserRepository> {
     Arc::new(UserRepository::with_users(vec![User {
         id: UserId(user_id),
         name: "writer".to_string(),
         email: "writer@example.com".to_string(),
         password: "hashed".to_string(),
         avatar: String::new(),
-        role: "user".to_string(),
-        banned: false,
+        role: role.to_string(),
+        banned,
     }]))
 }
 
@@ -781,6 +785,109 @@ async fn valid_author_write_paths_reach_persistence_error_branches() {
     .await
     .unwrap_err();
     assert!(matches!(submit_error, AppError::DatabaseError(_)));
+}
+
+#[tokio::test]
+async fn banned_author_write_paths_stop_before_persistence() {
+    let owner = Uuid::new_v4();
+    let banned_repo = repo_with_state(owner, "user", true);
+
+    let save_error = rule::save_draft(
+        claims(owner),
+        State(store_with(Vec::new(), Vec::new())),
+        State(failing_persistence()),
+        State(banned_repo.clone()),
+        Json(valid_save_payload("Save Valid")),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(save_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+
+    let update_id = Uuid::new_v4().to_string();
+    let update_error = rule::update_draft(
+        claims(owner),
+        State(store_with(
+            vec![draft(owner, &update_id, RuleStatus::Draft, 1)],
+            Vec::new(),
+        )),
+        State(failing_persistence()),
+        State(banned_repo.clone()),
+        Path(update_id),
+        Json(valid_save_payload("Update Valid")),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(update_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+
+    let submit_id = Uuid::new_v4().to_string();
+    let submit_error = rule::submit_review(
+        claims(owner),
+        State(store_with(
+            vec![draft(owner, &submit_id, RuleStatus::Draft, 1)],
+            Vec::new(),
+        )),
+        State(failing_persistence()),
+        State(banned_repo.clone()),
+        Path(submit_id),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(submit_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+
+    let fork_error = rule::fork_published_rule(
+        claims(owner),
+        State(store_with(
+            Vec::new(),
+            vec![published_rule("published-source", "Published Source")],
+        )),
+        State(failing_persistence()),
+        State(banned_repo),
+        Path("published-source".to_string()),
+        Json(ForkRuleRequest {
+            name: "My Copy".to_string(),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(fork_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+}
+
+#[tokio::test]
+async fn admin_can_unban_user_through_handler() {
+    let admin_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let repo = Arc::new(UserRepository::with_users(vec![
+        User {
+            id: UserId(admin_id),
+            name: "Admin".to_string(),
+            email: "admin@example.com".to_string(),
+            password: "hashed".to_string(),
+            avatar: String::new(),
+            role: "admin".to_string(),
+            banned: false,
+        },
+        User {
+            id: UserId(target_id),
+            name: "Writer".to_string(),
+            email: "writer@example.com".to_string(),
+            password: "hashed".to_string(),
+            avatar: String::new(),
+            role: "user".to_string(),
+            banned: true,
+        },
+    ]));
+
+    let Json(response) = rule::unban_user(
+        claims(admin_id),
+        State(repo.clone()),
+        Path(target_id.to_string()),
+    )
+    .await
+    .unwrap();
+
+    assert!(response.success);
+    let target = repo.find_by_id(&UserId(target_id)).await.unwrap().unwrap();
+    assert!(!target.banned, "解封接口应把 banned 标记清回 false");
 }
 
 #[tokio::test]

--- a/tests/rule_interface_coverage_tests.rs
+++ b/tests/rule_interface_coverage_tests.rs
@@ -801,7 +801,9 @@ async fn banned_author_write_paths_stop_before_persistence() {
     )
     .await
     .unwrap_err();
-    assert!(matches!(save_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+    assert!(
+        matches!(save_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作")
+    );
 
     let update_id = Uuid::new_v4().to_string();
     let update_error = rule::update_draft(
@@ -817,7 +819,9 @@ async fn banned_author_write_paths_stop_before_persistence() {
     )
     .await
     .unwrap_err();
-    assert!(matches!(update_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+    assert!(
+        matches!(update_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作")
+    );
 
     let submit_id = Uuid::new_v4().to_string();
     let submit_error = rule::submit_review(
@@ -832,7 +836,9 @@ async fn banned_author_write_paths_stop_before_persistence() {
     )
     .await
     .unwrap_err();
-    assert!(matches!(submit_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+    assert!(
+        matches!(submit_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作")
+    );
 
     let fork_error = rule::fork_published_rule(
         claims(owner),
@@ -849,7 +855,9 @@ async fn banned_author_write_paths_stop_before_persistence() {
     )
     .await
     .unwrap_err();
-    assert!(matches!(fork_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作"));
+    assert!(
+        matches!(fork_error, AppError::Forbidden(message) if message == "账号已被封禁，无法执行该操作")
+    );
 }
 
 #[tokio::test]

--- a/tests/user_login_avatar_http_tests.rs
+++ b/tests/user_login_avatar_http_tests.rs
@@ -61,6 +61,8 @@ mod infrastructure {
             email: String,
             password: String,
             avatar: String,
+            role: String,
+            banned: bool,
         }
 
         impl StoredUser {
@@ -71,8 +73,8 @@ mod infrastructure {
                     email: self.email,
                     password: self.password,
                     avatar: self.avatar,
-                    role: "user".to_string(),
-                    banned: false,
+                    role: self.role,
+                    banned: self.banned,
                 }
             }
         }
@@ -90,6 +92,18 @@ mod infrastructure {
                 password: &str,
                 avatar: &str,
             ) -> Self {
+                Self::with_user_state(id, name, email, password, avatar, "user", false)
+            }
+
+            pub fn with_user_state(
+                id: Uuid,
+                name: &str,
+                email: &str,
+                password: &str,
+                avatar: &str,
+                role: &str,
+                banned: bool,
+            ) -> Self {
                 let mut users = HashMap::new();
                 users.insert(
                     id,
@@ -99,6 +113,8 @@ mod infrastructure {
                         email: email.to_string(),
                         password: password.to_string(),
                         avatar: avatar.to_string(),
+                        role: role.to_string(),
+                        banned,
                     },
                 );
 
@@ -124,6 +140,8 @@ mod infrastructure {
                         email: user.email,
                         password: user.password,
                         avatar: user.avatar,
+                        role: user.role,
+                        banned: user.banned,
                     },
                 );
                 Ok(())
@@ -310,15 +328,22 @@ struct TestState {
 }
 
 fn test_state(upload_dir: PathBuf, avatar: &str) -> TestState {
-    TestState {
-        jwt_secret: JwtSecret(b"test-secret".to_vec()),
-        user: Arc::new(UserRepository::with_user(
+    test_state_with_repo(
+        upload_dir,
+        UserRepository::with_user(
             Uuid::from_u128(1),
             "alice",
             "alice@example.com",
             "password123",
             avatar,
-        )),
+        ),
+    )
+}
+
+fn test_state_with_repo(upload_dir: PathBuf, user_repo: UserRepository) -> TestState {
+    TestState {
+        jwt_secret: JwtSecret(b"test-secret".to_vec()),
+        user: Arc::new(user_repo),
         verification_codes: Arc::new(RwLock::new(HashMap::new())),
         email: EmailSender,
         upload_dir: UploadDir(Arc::new(upload_dir)),
@@ -432,6 +457,41 @@ async fn login_accepts_username_in_email_field() {
             .as_str()
             .is_some_and(|token| !token.is_empty())
     );
+}
+
+#[tokio::test]
+async fn banned_user_login_returns_forbidden_without_token() {
+    let upload_dir = unique_upload_dir("banned-login");
+    let app = app(test_state_with_repo(
+        upload_dir,
+        UserRepository::with_user_state(
+            Uuid::from_u128(1),
+            "alice",
+            "alice@example.com",
+            "password123",
+            "/static/avatars/existing.png",
+            "user",
+            true,
+        ),
+    ));
+
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/api/user/login",
+            json!({
+                "email": "alice",
+                "password": "password123"
+            }),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = response_json(response).await;
+    assert_eq!(body["success"], false);
+    assert_eq!(body["message"], "账号已被封禁");
+    assert!(body["data"].is_null());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add login coverage for banned accounts returning `403`
- cover banned-author guards across save/update/submit/fork rule flows and blocked market review creation
- cover the admin unban handler contract path without touching production code

## Related Issues
- Closes #135
- Closes #154
- Related #153
- Related #155

## Verification
- `cargo test --verbose`

## Review
- `~/.codex/bin/claude-review --base main`
- Record: `/home/lih/.codex/cross-agent-review/Data-erhuo-.worktrees-WildCard_BackEnd-test-latest-rule-market-contracts/claude-code/20260614T035143Z-standard.json`