### PR TITLE
feat: 举报审核惩罚模型升级（时长/撤销/合并/筛选/同时封禁）

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -5,12 +5,14 @@ CREATE TABLE IF NOT EXISTS users (
     password VARCHAR(255) NOT NULL,
     avatar VARCHAR(512) NOT NULL DEFAULT '',
     role VARCHAR(16) NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
-    banned BOOLEAN NOT NULL DEFAULT false
+    banned BOOLEAN NOT NULL DEFAULT false,
+    banned_until BIGINT
 );
 
 ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar VARCHAR(512) NOT NULL DEFAULT '';
 ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(16) NOT NULL DEFAULT 'user';
 ALTER TABLE users ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS banned_until BIGINT;
 
 CREATE INDEX IF NOT EXISTS idx_users_name ON users(name);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
@@ -110,12 +112,33 @@ CREATE TABLE IF NOT EXISTS reports (
     status VARCHAR(32) NOT NULL DEFAULT 'pending',
     context JSONB NOT NULL DEFAULT '{}'::jsonb,
     action_log JSONB NOT NULL DEFAULT '[]'::jsonb,
+    merged_by_punishment_id VARCHAR(128),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS merged_by_punishment_id VARCHAR(128);
+
 CREATE INDEX IF NOT EXISTS idx_reports_status_created
     ON reports(status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS punishments (
+    id UUID PRIMARY KEY,
+    report_id UUID NOT NULL,
+    action VARCHAR(16) NOT NULL,
+    scope VARCHAR(8) NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT true,
+    ban_days INT,
+    banned_until BIGINT,
+    rule_removed BOOLEAN NOT NULL DEFAULT false,
+    target_user_id VARCHAR(128),
+    target_rule_id VARCHAR(128),
+    affected_report_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at BIGINT NOT NULL,
+    revoked_at BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_punishments_report ON punishments(report_id);
 
 -- 首任管理员：保证 Tanhhhhtjy 始终拥有 admin 角色（手动改回 user 不会被覆盖，
 -- 因为应用启动时使用了 AND role <> 'admin' 守卫；init.sql 仅用于全新部署）。

--- a/src/domain/report.rs
+++ b/src/domain/report.rs
@@ -61,28 +61,231 @@ impl ReportStatus {
     }
 }
 
-/// 管理员处理动作：ban_user / ban_rule / dismiss，与前端 `ReportAction` 对齐。
-/// 产品决策：后端只记状态，不真正执行封禁 / 下架。
+/// 管理员处理动作，与前端 `ReportAction` 对齐：
+/// ban_user / ban_rule / ban_both / dismiss / revoke。
+/// ban_both 同时封用户 + 下架规则；revoke 撤销一条已落地的惩罚（完全逆转）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReportAction {
     BanUser,
     BanRule,
+    BanBoth,
     Dismiss,
+    Revoke,
 }
 
 impl ReportAction {
+    /// 出网 / 入库字面值（snake_case），与 serde 序列化一致。
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReportAction::BanUser => "ban_user",
+            ReportAction::BanRule => "ban_rule",
+            ReportAction::BanBoth => "ban_both",
+            ReportAction::Dismiss => "dismiss",
+            ReportAction::Revoke => "revoke",
+        }
+    }
+
+    /// 从 DB / 字符串解析；未知值返回 None。
+    pub fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "ban_user" => Some(ReportAction::BanUser),
+            "ban_rule" => Some(ReportAction::BanRule),
+            "ban_both" => Some(ReportAction::BanBoth),
+            "dismiss" => Some(ReportAction::Dismiss),
+            "revoke" => Some(ReportAction::Revoke),
+            _ => None,
+        }
+    }
+
     /// 动作 → 落地状态映射（纯函数，便于单测）：
-    /// dismiss 视为驳回举报（rejected）；其余（ban_user / ban_rule）视为已处理（resolved）。
+    /// dismiss 视为驳回举报（rejected）；revoke 把举报退回 pending；
+    /// ban_user / ban_rule / ban_both 视为已处理（resolved）。
     pub fn resulting_status(self) -> ReportStatus {
         match self {
             ReportAction::Dismiss => ReportStatus::Rejected,
-            ReportAction::BanUser | ReportAction::BanRule => ReportStatus::Resolved,
+            ReportAction::Revoke => ReportStatus::Pending,
+            ReportAction::BanUser | ReportAction::BanRule | ReportAction::BanBoth => {
+                ReportStatus::Resolved
+            }
         }
     }
 }
 
+/// 惩罚作用域，与前端 `PunishmentScope` 对齐：user / rule / both。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PunishmentScope {
+    User,
+    Rule,
+    Both,
+}
+
+impl PunishmentScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PunishmentScope::User => "user",
+            PunishmentScope::Rule => "rule",
+            PunishmentScope::Both => "both",
+        }
+    }
+
+    pub fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "user" => Some(PunishmentScope::User),
+            "rule" => Some(PunishmentScope::Rule),
+            "both" => Some(PunishmentScope::Both),
+            _ => None,
+        }
+    }
+}
+
+/// 封禁判断纯函数：banned_until 为 None 视为未封禁；有值且大于 now 才算封禁中。
+/// 解封 = 把 banned_until 置 None（不删数据，可逆）。
+pub fn is_banned(banned_until: Option<i64>, now: i64) -> bool {
+    banned_until.is_some_and(|until| until > now)
+}
+
+/// 动作 → 作用域映射（纯函数）：
+/// ban_user → user，ban_rule → rule，ban_both → both，其余（dismiss / revoke）→ None。
+pub fn action_scope(action: ReportAction) -> Option<PunishmentScope> {
+    match action {
+        ReportAction::BanUser => Some(PunishmentScope::User),
+        ReportAction::BanRule => Some(PunishmentScope::Rule),
+        ReportAction::BanBoth => Some(PunishmentScope::Both),
+        ReportAction::Dismiss | ReportAction::Revoke => None,
+    }
+}
+
+/// 合并判定纯函数，逐一对齐 FE `isSamePunishedTarget`：
+/// 按 scope 判断候选举报是否与被罚目标同 user / 同 rule。空字符串视为"无目标"不匹配。
+pub fn same_punished_target(
+    scope: PunishmentScope,
+    punished_user_id: Option<&str>,
+    punished_rule_id: Option<&str>,
+    candidate_user_id: Option<&str>,
+    candidate_rule_id: Option<&str>,
+) -> bool {
+    let same_user = punished_user_id
+        .filter(|id| !id.is_empty())
+        .is_some_and(|id| candidate_user_id == Some(id));
+    let same_rule = punished_rule_id
+        .filter(|id| !id.is_empty())
+        .is_some_and(|id| candidate_rule_id == Some(id));
+    match scope {
+        PunishmentScope::User => same_user,
+        PunishmentScope::Rule => same_rule,
+        PunishmentScope::Both => same_user || same_rule,
+    }
+}
+
+/// 处理动作校验纯函数，逐一对齐 FE `validateLocalAction`。校验通过返回 Ok，
+/// 否则返回与 FE 同口径的中文错误信息（上层包成 400）。
+/// `has_rule_author`：targetRule.authorId 或 params.ruleAuthorId 任一存在即为 true。
+pub fn validate_action(
+    action: ReportAction,
+    status: ReportStatus,
+    has_active_punishment: bool,
+    ban_days: Option<i64>,
+    target_type: ReportTargetType,
+    has_rule_author: bool,
+) -> Result<(), String> {
+    if action == ReportAction::Revoke {
+        return if has_active_punishment {
+            Ok(())
+        } else {
+            Err("当前举报没有可撤销的有效惩罚".to_string())
+        };
+    }
+    if status != ReportStatus::Pending {
+        return Err("该举报已处理，不能重复执行处罚".to_string());
+    }
+    if matches!(action, ReportAction::BanUser | ReportAction::BanBoth) && ban_days.is_none() {
+        return Err("请选择用户封禁时长".to_string());
+    }
+    let rule_like = matches!(
+        target_type,
+        ReportTargetType::Rule | ReportTargetType::Review
+    );
+    if action == ReportAction::BanUser && rule_like && !has_rule_author {
+        return Err("缺少规则作者 ID，无法封禁作者".to_string());
+    }
+    if action == ReportAction::BanBoth && !has_rule_author {
+        return Err("缺少规则作者 ID，无法封禁作者".to_string());
+    }
+    Ok(())
+}
+
+/// 举报人 / 被举报用户 / 被举报规则的结构化对象，对齐 FE 的
+/// `ReportUser` / `ReportTargetUser` / `ReportTargetRule`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReportUser {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub avatar: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportTargetUser {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avatar: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportTargetRule {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "authorId", default, skip_serializing_if = "Option::is_none")]
+    pub author_id: Option<String>,
+    #[serde(
+        rename = "authorName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub author_name: Option<String>,
+}
+
+/// 惩罚记录，序列化字段逐一对齐 FE `ReportPunishment`（camelCase）。
+/// report_id / target_user_id / target_rule_id 是 DB 内部字段（撤销时逆转用），
+/// 不属于 FE 契约，跳过序列化。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Punishment {
+    pub id: String,
+    pub action: ReportAction,
+    pub scope: PunishmentScope,
+    pub active: bool,
+    #[serde(rename = "banDays", default, skip_serializing_if = "Option::is_none")]
+    pub ban_days: Option<i64>,
+    #[serde(
+        rename = "bannedUntil",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub banned_until: Option<i64>,
+    #[serde(rename = "ruleRemoved")]
+    pub rule_removed: bool,
+    #[serde(rename = "affectedReportIds", default)]
+    pub affected_report_ids: Vec<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: i64,
+    #[serde(rename = "revokedAt", default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<i64>,
+    #[serde(skip)]
+    pub report_id: String,
+    #[serde(skip)]
+    pub target_user_id: Option<String>,
+    #[serde(skip)]
+    pub target_rule_id: Option<String>,
+}
+
 /// 单条处理记录，内嵌在 reports.action_log JSONB 数组里。
+/// `params` 透传 FE `ReportActionParams`（原始 JSON），便于审计回溯当时的调参。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReportActionLog {
     pub id: String,
@@ -93,6 +296,8 @@ pub struct ReportActionLog {
     pub note: String,
     #[serde(rename = "createdAt")]
     pub created_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
 }
 
 /// 举报完整对象。`context` 用原始 JSON 透传（FE 的 ReportContext 字段都是可选的，
@@ -100,6 +305,10 @@ pub struct ReportActionLog {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Report {
     pub id: String,
+    /// 结构化举报人对象，对齐 FE `reporter`。FE 同时保留旧扁平字段做 deprecated 兼容，
+    /// 因此序列化时 reporter 结构 + reporterId/reporterName/reporterAvatar 两套都输出。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reporter: Option<ReportUser>,
     #[serde(rename = "reporterId")]
     pub reporter_id: String,
     #[serde(rename = "reporterName")]
@@ -115,6 +324,19 @@ pub struct Report {
     pub target_type: ReportTargetType,
     #[serde(rename = "targetId")]
     pub target_id: String,
+    /// 结构化被举报用户 / 规则，对齐 FE `targetUser` / `targetRule`。读取时按需补齐。
+    #[serde(
+        rename = "targetUser",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_user: Option<ReportTargetUser>,
+    #[serde(
+        rename = "targetRule",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_rule: Option<ReportTargetRule>,
     #[serde(default)]
     pub reason: String,
     #[serde(default)]
@@ -126,6 +348,319 @@ pub struct Report {
     pub updated_at: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<serde_json::Value>,
+    /// 当前生效（或最近一次）的惩罚，读取时查 active punishment 补齐。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub punishment: Option<Punishment>,
+    /// 被某条惩罚合并时记录该惩罚 ID，对齐 FE `mergedByPunishmentId`。
+    #[serde(
+        rename = "mergedByPunishmentId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merged_by_punishment_id: Option<String>,
     #[serde(rename = "actionLog", default)]
     pub action_log: Vec<ReportActionLog>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_serde_ban_both_and_revoke() {
+        assert_eq!(
+            serde_json::to_value(ReportAction::BanBoth).unwrap(),
+            serde_json::json!("ban_both")
+        );
+        assert_eq!(
+            serde_json::to_value(ReportAction::Revoke).unwrap(),
+            serde_json::json!("revoke")
+        );
+        let back: ReportAction = serde_json::from_value(serde_json::json!("ban_both")).unwrap();
+        assert_eq!(back, ReportAction::BanBoth);
+        let back: ReportAction = serde_json::from_value(serde_json::json!("revoke")).unwrap();
+        assert_eq!(back, ReportAction::Revoke);
+        assert_eq!(
+            ReportAction::from_db_str("ban_both"),
+            Some(ReportAction::BanBoth)
+        );
+        assert_eq!(
+            ReportAction::from_db_str("revoke"),
+            Some(ReportAction::Revoke)
+        );
+        assert_eq!(ReportAction::from_db_str("nope"), None);
+        assert_eq!(ReportAction::BanBoth.as_str(), "ban_both");
+        assert_eq!(ReportAction::Revoke.as_str(), "revoke");
+    }
+
+    #[test]
+    fn revoke_action_maps_to_pending_status() {
+        assert_eq!(
+            ReportAction::Revoke.resulting_status(),
+            ReportStatus::Pending
+        );
+        assert_eq!(
+            ReportAction::BanBoth.resulting_status(),
+            ReportStatus::Resolved
+        );
+    }
+
+    #[test]
+    fn punishment_serializes_camel_case() {
+        let punishment = Punishment {
+            id: "punishment-1".to_string(),
+            action: ReportAction::BanBoth,
+            scope: PunishmentScope::Both,
+            active: true,
+            ban_days: Some(7),
+            banned_until: Some(1_700_000_604_800_000),
+            rule_removed: true,
+            affected_report_ids: vec!["r-2".to_string(), "r-3".to_string()],
+            created_at: 1_700_000_000_000,
+            revoked_at: None,
+            report_id: "r-1".to_string(),
+            target_user_id: Some("u-1".to_string()),
+            target_rule_id: Some("rule_x".to_string()),
+        };
+        let json = serde_json::to_value(&punishment).unwrap();
+        assert_eq!(json.get("banDays").and_then(|v| v.as_i64()), Some(7));
+        assert_eq!(
+            json.get("bannedUntil").and_then(|v| v.as_i64()),
+            Some(1_700_000_604_800_000)
+        );
+        assert_eq!(
+            json.get("ruleRemoved").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            json.get("affectedReportIds")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(2)
+        );
+        assert_eq!(
+            json.get("createdAt").and_then(|v| v.as_i64()),
+            Some(1_700_000_000_000)
+        );
+        // revokedAt 为 None 时不输出；DB 内部字段不出网。
+        assert!(json.get("revokedAt").is_none());
+        assert!(json.get("reportId").is_none());
+        assert!(json.get("targetUserId").is_none());
+        assert_eq!(
+            json.get("action").and_then(|v| v.as_str()),
+            Some("ban_both")
+        );
+        assert_eq!(json.get("scope").and_then(|v| v.as_str()), Some("both"));
+    }
+
+    #[test]
+    fn is_banned_respects_until_vs_now() {
+        let now = 1_700_000_000_000;
+        assert!(is_banned(Some(now + 1), now));
+        assert!(!is_banned(Some(now - 1), now));
+        assert!(!is_banned(Some(now), now));
+        assert!(!is_banned(None, now));
+    }
+
+    #[test]
+    fn action_scope_maps_three_ban_actions() {
+        assert_eq!(
+            action_scope(ReportAction::BanUser),
+            Some(PunishmentScope::User)
+        );
+        assert_eq!(
+            action_scope(ReportAction::BanRule),
+            Some(PunishmentScope::Rule)
+        );
+        assert_eq!(
+            action_scope(ReportAction::BanBoth),
+            Some(PunishmentScope::Both)
+        );
+        assert_eq!(action_scope(ReportAction::Dismiss), None);
+        assert_eq!(action_scope(ReportAction::Revoke), None);
+    }
+
+    #[test]
+    fn same_punished_target_matches_per_scope() {
+        // scope=user：只看 user 命中。
+        assert!(same_punished_target(
+            PunishmentScope::User,
+            Some("u-1"),
+            Some("rule-1"),
+            Some("u-1"),
+            Some("rule-other"),
+        ));
+        assert!(!same_punished_target(
+            PunishmentScope::User,
+            Some("u-1"),
+            Some("rule-1"),
+            Some("u-2"),
+            Some("rule-1"),
+        ));
+        // scope=rule：只看 rule 命中。
+        assert!(same_punished_target(
+            PunishmentScope::Rule,
+            Some("u-1"),
+            Some("rule-1"),
+            Some("u-2"),
+            Some("rule-1"),
+        ));
+        // scope=both：user 或 rule 任一命中。
+        assert!(same_punished_target(
+            PunishmentScope::Both,
+            Some("u-1"),
+            None,
+            Some("u-1"),
+            None,
+        ));
+        assert!(same_punished_target(
+            PunishmentScope::Both,
+            None,
+            Some("rule-1"),
+            None,
+            Some("rule-1"),
+        ));
+        // 空 / None 目标不匹配。
+        assert!(!same_punished_target(
+            PunishmentScope::User,
+            Some(""),
+            None,
+            Some(""),
+            None,
+        ));
+        assert!(!same_punished_target(
+            PunishmentScope::User,
+            None,
+            None,
+            Some("u-1"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn validate_action_revoke_requires_active_punishment() {
+        assert!(
+            validate_action(
+                ReportAction::Revoke,
+                ReportStatus::Resolved,
+                true,
+                None,
+                ReportTargetType::User,
+                false,
+            )
+            .is_ok()
+        );
+        let err = validate_action(
+            ReportAction::Revoke,
+            ReportStatus::Resolved,
+            false,
+            None,
+            ReportTargetType::User,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, "当前举报没有可撤销的有效惩罚");
+    }
+
+    #[test]
+    fn validate_action_ban_user_requires_ban_days() {
+        let err = validate_action(
+            ReportAction::BanUser,
+            ReportStatus::Pending,
+            false,
+            None,
+            ReportTargetType::User,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(err, "请选择用户封禁时长");
+        assert!(
+            validate_action(
+                ReportAction::BanUser,
+                ReportStatus::Pending,
+                false,
+                Some(7),
+                ReportTargetType::User,
+                true,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_action_rejects_non_pending_for_punishment() {
+        let err = validate_action(
+            ReportAction::BanRule,
+            ReportStatus::Resolved,
+            false,
+            None,
+            ReportTargetType::Rule,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(err, "该举报已处理，不能重复执行处罚");
+    }
+
+    #[test]
+    fn validate_action_ban_user_on_rule_needs_author() {
+        let err = validate_action(
+            ReportAction::BanUser,
+            ReportStatus::Pending,
+            false,
+            Some(3),
+            ReportTargetType::Rule,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, "缺少规则作者 ID，无法封禁作者");
+        // review 类同理。
+        let err = validate_action(
+            ReportAction::BanUser,
+            ReportStatus::Pending,
+            false,
+            Some(3),
+            ReportTargetType::Review,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, "缺少规则作者 ID，无法封禁作者");
+        // 有作者则通过。
+        assert!(
+            validate_action(
+                ReportAction::BanUser,
+                ReportStatus::Pending,
+                false,
+                Some(3),
+                ReportTargetType::Rule,
+                true,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_action_ban_both_always_needs_author() {
+        let err = validate_action(
+            ReportAction::BanBoth,
+            ReportStatus::Pending,
+            false,
+            Some(5),
+            ReportTargetType::User,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, "缺少规则作者 ID，无法封禁作者");
+    }
+
+    #[test]
+    fn punishment_scope_db_roundtrip() {
+        for s in [
+            PunishmentScope::User,
+            PunishmentScope::Rule,
+            PunishmentScope::Both,
+        ] {
+            assert_eq!(PunishmentScope::from_db_str(s.as_str()), Some(s));
+        }
+        assert_eq!(PunishmentScope::from_db_str("garbage"), None);
+    }
 }

--- a/src/domain/user.rs
+++ b/src/domain/user.rs
@@ -23,10 +23,13 @@ pub struct User {
     /// 不增加 SQL 解码层。校验集中在 ensure_admin / init.sql CHECK 约束里。
     #[serde(default = "default_role")]
     pub role: String,
-    /// 是否被封禁。封禁只标记不删数据，可解封。登录与写接口处校验此字段，
-    /// 鉴权（TokenClaims）不查库以免每次请求多一次 DB 往返。
+    /// 是否被封禁（旧 bool 列，保留兼容不再用于拦截判断）。封禁拦截改读 `banned_until`。
     #[serde(default)]
     pub banned: bool,
+    /// 封禁到期时间戳（毫秒）。None = 未封禁；有值且大于当前时间 = 封禁中。
+    /// 封禁 = 写 now + banDays*86400000；解封 = 置 None。可逆、不删数据。
+    #[serde(default)]
+    pub banned_until: Option<i64>,
 }
 
 fn default_role() -> String {
@@ -47,6 +50,7 @@ mod tests {
             avatar: String::new(),
             role: "user".to_string(),
             banned: true,
+            banned_until: Some(1_700_000_000_000),
         };
         let json = serde_json::to_value(&user).unwrap();
         assert_eq!(json.get("banned").and_then(|v| v.as_bool()), Some(true));

--- a/src/infrastructure/user.rs
+++ b/src/infrastructure/user.rs
@@ -44,7 +44,7 @@ impl UserRepository {
 
     pub async fn find_by_name(&self, name: &str) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.name = $1",
+            "SELECT id, name, email, password, avatar, role, banned, banned_until FROM users WHERE users.name = $1",
         )
         .bind(name)
         .fetch_optional(&self.pool)
@@ -58,6 +58,7 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         });
 
         Ok(user)
@@ -65,7 +66,7 @@ impl UserRepository {
 
     pub async fn find_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.email = $1",
+            "SELECT id, name, email, password, avatar, role, banned, banned_until FROM users WHERE users.email = $1",
         )
         .bind(email)
         .fetch_optional(&self.pool)
@@ -79,6 +80,7 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         });
 
         Ok(user)
@@ -86,7 +88,7 @@ impl UserRepository {
 
     pub async fn find_by_id(&self, user_id: &UserId) -> Result<Option<User>, AppError> {
         let user = sqlx::query(
-            "SELECT id, name, email, password, avatar, role, banned FROM users WHERE users.id = $1",
+            "SELECT id, name, email, password, avatar, role, banned, banned_until FROM users WHERE users.id = $1",
         )
         .bind(user_id.0)
         .fetch_optional(&self.pool)
@@ -100,6 +102,7 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         });
 
         Ok(user)
@@ -111,7 +114,7 @@ impl UserRepository {
         username: &str,
     ) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET name = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
+            "UPDATE users SET name = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned, banned_until",
         )
         .bind(username)
         .bind(user_id.0)
@@ -141,12 +144,13 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         })
     }
 
     pub async fn update_email(&self, user_id: &UserId, email: &str) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET email = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
+            "UPDATE users SET email = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned, banned_until",
         )
         .bind(email)
         .bind(user_id.0)
@@ -176,6 +180,7 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         })
     }
 
@@ -196,7 +201,7 @@ impl UserRepository {
 
     pub async fn update_avatar(&self, user_id: &UserId, avatar: &str) -> Result<User, AppError> {
         let user = sqlx::query(
-            "UPDATE users SET avatar = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned",
+            "UPDATE users SET avatar = $1 WHERE id = $2 RETURNING id, name, email, password, avatar, role, banned, banned_until",
         )
         .bind(avatar)
         .bind(user_id.0)
@@ -212,6 +217,7 @@ impl UserRepository {
             avatar: user.get("avatar"),
             role: user.get("role"),
             banned: user.get("banned"),
+            banned_until: user.get("banned_until"),
         })
     }
 
@@ -219,6 +225,24 @@ impl UserRepository {
     pub async fn set_user_banned(&self, user_id: &UserId, banned: bool) -> Result<(), AppError> {
         sqlx::query("UPDATE users SET banned = $1 WHERE id = $2")
             .bind(banned)
+            .bind(user_id.0)
+            .execute(&self.pool)
+            .await
+            .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        Ok(())
+    }
+
+    /// 设置封禁到期时间戳（毫秒）。Some(until) = 封禁至该时刻；None = 解封。
+    /// 同步把旧 banned bool 列写成 until.is_some()，保持两列一致（旧列仅作历史兼容）。
+    pub async fn set_user_banned_until(
+        &self,
+        user_id: &UserId,
+        until: Option<i64>,
+    ) -> Result<(), AppError> {
+        sqlx::query("UPDATE users SET banned_until = $1, banned = $2 WHERE id = $3")
+            .bind(until)
+            .bind(until.is_some())
             .bind(user_id.0)
             .execute(&self.pool)
             .await

--- a/src/interface/report.rs
+++ b/src/interface/report.rs
@@ -9,7 +9,11 @@ use sqlx::{PgPool, Row, postgres::PgRow};
 use uuid::Uuid;
 
 use crate::{
-    domain::report::{Report, ReportAction, ReportActionLog, ReportStatus, ReportTargetType},
+    domain::report::{
+        Punishment, PunishmentScope, Report, ReportAction, ReportActionLog, ReportStatus,
+        ReportTargetRule, ReportTargetType, ReportTargetUser, ReportUser, action_scope,
+        same_punished_target, validate_action,
+    },
     domain::user::UserId,
     error::AppError,
     infrastructure::user::UserRepository,
@@ -44,16 +48,49 @@ pub struct SubmitReportPayload {
     pub context: Option<serde_json::Value>,
 }
 
-/// 处理举报请求体，对齐 FE `ReportActionPayload`。`params` 前端可能传任意调参，
-/// 后端目前只记状态不执行，因此接收但不使用（保留字段避免反序列化失败）。
+/// 处理动作的可选调参，对齐 FE `ReportActionParams`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReportActionParams {
+    #[serde(
+        default,
+        rename = "targetType",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[allow(dead_code)]
+    pub target_type: Option<String>,
+    #[serde(default, rename = "targetId", skip_serializing_if = "Option::is_none")]
+    #[allow(dead_code)]
+    pub target_id: Option<String>,
+    #[serde(
+        default,
+        rename = "targetUserId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_user_id: Option<String>,
+    #[serde(
+        default,
+        rename = "targetRuleId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_rule_id: Option<String>,
+    #[serde(
+        default,
+        rename = "ruleAuthorId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rule_author_id: Option<String>,
+    #[serde(default, rename = "banDays", skip_serializing_if = "Option::is_none")]
+    pub ban_days: Option<i64>,
+}
+
+/// 处理举报请求体，对齐 FE `ReportActionPayload`。`params` 携带封禁时长 / 目标覆盖等调参。
 #[derive(Debug, Deserialize)]
 pub struct ReportActionPayload {
     pub action: ReportAction,
     #[serde(default)]
     pub note: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
-    pub params: Option<serde_json::Value>,
+    pub params: Option<ReportActionParams>,
 }
 
 /// GET /api/reports 的查询参数，对齐 FE `ReportQuery`。
@@ -66,6 +103,10 @@ pub struct ReportListQuery {
     pub target_type: Option<String>,
     #[serde(default)]
     pub keyword: Option<String>,
+    #[serde(default, rename = "targetUser")]
+    pub target_user: Option<String>,
+    #[serde(default, rename = "targetRule")]
+    pub target_rule: Option<String>,
     #[serde(default)]
     #[allow(dead_code)]
     pub page: Option<u32>,
@@ -82,8 +123,46 @@ pub struct ReportPersistence {
     pub pool: PgPool,
 }
 
-/// 判断一条举报是否命中关键字（大小写不敏感，模糊匹配 target_id / reason / details /
-/// reporter_name / context.targetLabel）。抽成纯函数便于单测，口径与 FE filterLocalReports 对齐。
+/// 派生被举报用户 ID，对齐 FE `getTargetUserId`：
+/// 优先 targetUser.id，否则 user / player_behavior 类用 target_id，其余 None。
+pub fn report_target_user_id(report: &Report) -> Option<String> {
+    if let Some(tu) = &report.target_user
+        && !tu.id.is_empty()
+    {
+        return Some(tu.id.clone());
+    }
+    match report.target_type {
+        ReportTargetType::User | ReportTargetType::PlayerBehavior => Some(report.target_id.clone()),
+        _ => None,
+    }
+}
+
+/// 派生被举报规则 ID，对齐 FE `getTargetRuleId`：
+/// 优先 targetRule.id，否则 context.ruleId，否则 rule / review 类用 target_id，其余 None。
+pub fn report_target_rule_id(report: &Report) -> Option<String> {
+    if let Some(tr) = &report.target_rule
+        && !tr.id.is_empty()
+    {
+        return Some(tr.id.clone());
+    }
+    if let Some(rule_id) = report
+        .context
+        .as_ref()
+        .and_then(|ctx| ctx.get("ruleId"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Some(rule_id.to_string());
+    }
+    match report.target_type {
+        ReportTargetType::Rule | ReportTargetType::Review => Some(report.target_id.clone()),
+        _ => None,
+    }
+}
+
+/// 判断一条举报是否命中关键字（大小写不敏感）。匹配 target_id / reason / details /
+/// reporter_name / context.targetLabel，以及结构化 target_user / target_rule 的 id+name。
+/// 口径与 FE filterLocalReports 对齐。抽成纯函数便于单测。
 pub fn report_matches_keyword(report: &Report, keyword: &str) -> bool {
     let needle = keyword.trim().to_lowercase();
     if needle.is_empty() {
@@ -95,15 +174,66 @@ pub fn report_matches_keyword(report: &Report, keyword: &str) -> bool {
         .and_then(|ctx| ctx.get("targetLabel"))
         .and_then(|v| v.as_str())
         .unwrap_or_default();
-    [
-        report.target_id.as_str(),
-        report.reason.as_str(),
-        report.details.as_str(),
-        report.reporter_name.as_str(),
-        target_label,
-    ]
-    .iter()
-    .any(|field| field.to_lowercase().contains(&needle))
+    let mut haystack: Vec<String> = vec![
+        report.target_id.clone(),
+        report.reason.clone(),
+        report.details.clone(),
+        report.reporter_name.clone(),
+        target_label.to_string(),
+    ];
+    if let Some(tu) = &report.target_user {
+        haystack.push(tu.id.clone());
+        if let Some(name) = &tu.name {
+            haystack.push(name.clone());
+        }
+    }
+    if let Some(tr) = &report.target_rule {
+        haystack.push(tr.id.clone());
+        if let Some(name) = &tr.name {
+            haystack.push(name.clone());
+        }
+    }
+    haystack
+        .iter()
+        .any(|field| field.to_lowercase().contains(&needle))
+}
+
+/// targetUser 过滤纯函数，对齐 FE：匹配 target_user.id / target_user.name / 派生 user id。
+pub fn report_matches_target_user(report: &Report, query: &str) -> bool {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    let mut values: Vec<String> = Vec::new();
+    if let Some(tu) = &report.target_user {
+        values.push(tu.id.clone());
+        if let Some(name) = &tu.name {
+            values.push(name.clone());
+        }
+    }
+    if let Some(id) = report_target_user_id(report) {
+        values.push(id);
+    }
+    values.iter().any(|v| v.to_lowercase().contains(&needle))
+}
+
+/// targetRule 过滤纯函数，对齐 FE：匹配 target_rule.id / target_rule.name / 派生 rule id。
+pub fn report_matches_target_rule(report: &Report, query: &str) -> bool {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    let mut values: Vec<String> = Vec::new();
+    if let Some(tr) = &report.target_rule {
+        values.push(tr.id.clone());
+        if let Some(name) = &tr.name {
+            values.push(name.clone());
+        }
+    }
+    if let Some(id) = report_target_rule_id(report) {
+        values.push(id);
+    }
+    values.iter().any(|v| v.to_lowercase().contains(&needle))
 }
 
 /// 把 context 规范化为"可选"：DB 里空对象 / JSON null 视为没有 context（返回 None），
@@ -151,6 +281,50 @@ impl ReportPersistence {
         .await
         .inspect_err(|e| tracing::warn!("Database error {e}"))?;
 
+        // 合并联动：reports 加 merged_by_punishment_id，记录被哪条惩罚合并。幂等升级。
+        sqlx::query(
+            r#"
+            ALTER TABLE reports
+                ADD COLUMN IF NOT EXISTS merged_by_punishment_id VARCHAR(128)
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        // 惩罚独立表：一条 action 落地一条惩罚记录，撤销时逆转用。
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS punishments (
+                id UUID PRIMARY KEY,
+                report_id UUID NOT NULL,
+                action VARCHAR(16) NOT NULL,
+                scope VARCHAR(8) NOT NULL,
+                active BOOLEAN NOT NULL DEFAULT true,
+                ban_days INT,
+                banned_until BIGINT,
+                rule_removed BOOLEAN NOT NULL DEFAULT false,
+                target_user_id VARCHAR(128),
+                target_rule_id VARCHAR(128),
+                affected_report_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                created_at BIGINT NOT NULL,
+                revoked_at BIGINT
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_punishments_report ON punishments(report_id)
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
         Ok(())
     }
 
@@ -168,13 +342,13 @@ impl ReportPersistence {
             INSERT INTO reports (
                 id, reporter_id, reporter_name, reporter_avatar,
                 target_type, target_id, reason, details, status,
-                context, action_log,
+                context, action_log, merged_by_punishment_id,
                 created_at, updated_at
             )
             VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
-                to_timestamp($12::double precision / 1000.0),
-                to_timestamp($13::double precision / 1000.0)
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                to_timestamp($13::double precision / 1000.0),
+                to_timestamp($14::double precision / 1000.0)
             )
             "#,
         )
@@ -189,6 +363,7 @@ impl ReportPersistence {
         .bind(report.status.as_str())
         .bind(context)
         .bind(action_log)
+        .bind(&report.merged_by_punishment_id)
         .bind(report.created_at)
         .bind(report.updated_at)
         .execute(&self.pool)
@@ -219,6 +394,7 @@ impl ReportPersistence {
                 status,
                 context,
                 action_log,
+                merged_by_punishment_id,
                 (EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_at,
                 (EXTRACT(EPOCH FROM updated_at) * 1000)::bigint AS updated_at
             FROM reports
@@ -251,6 +427,7 @@ impl ReportPersistence {
                 status,
                 context,
                 action_log,
+                merged_by_punishment_id,
                 (EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_at,
                 (EXTRACT(EPOCH FROM updated_at) * 1000)::bigint AS updated_at
             FROM reports
@@ -274,12 +451,13 @@ impl ReportPersistence {
         Ok(row.get::<i64, _>("count"))
     }
 
-    /// 处理举报：更新 status / updated_at，并把整段 action_log 覆盖回写。
+    /// 处理举报：更新 status / updated_at / merged_by_punishment_id，并把整段 action_log 覆盖回写。
     pub async fn update_action(
         &self,
         id: &Uuid,
         status: ReportStatus,
         action_log: &[ReportActionLog],
+        merged_by_punishment_id: Option<&str>,
         updated_at: i64,
     ) -> Result<(), AppError> {
         let action_log = serde_json::to_value(action_log).map_err(AppError::JsonError)?;
@@ -288,13 +466,15 @@ impl ReportPersistence {
             UPDATE reports
             SET status = $2,
                 action_log = $3,
-                updated_at = to_timestamp($4::double precision / 1000.0)
+                merged_by_punishment_id = $4,
+                updated_at = to_timestamp($5::double precision / 1000.0)
             WHERE id = $1
             "#,
         )
         .bind(id)
         .bind(status.as_str())
         .bind(action_log)
+        .bind(merged_by_punishment_id)
         .bind(updated_at)
         .execute(&self.pool)
         .await
@@ -302,6 +482,206 @@ impl ReportPersistence {
 
         Ok(())
     }
+
+    /// 写入一条惩罚记录。affected_report_ids 以 JSONB 数组存储。
+    pub async fn insert_punishment(&self, punishment: &Punishment) -> Result<(), AppError> {
+        let id = Uuid::parse_str(&punishment.id)
+            .map_err(|e| AppError::InvalidInput(format!("惩罚 ID 必须是 UUID：{e}")))?;
+        let report_id = Uuid::parse_str(&punishment.report_id)
+            .map_err(|e| AppError::InvalidInput(format!("举报 ID 必须是 UUID：{e}")))?;
+        let affected =
+            serde_json::to_value(&punishment.affected_report_ids).map_err(AppError::JsonError)?;
+        sqlx::query(
+            r#"
+            INSERT INTO punishments (
+                id, report_id, action, scope, active, ban_days, banned_until,
+                rule_removed, target_user_id, target_rule_id, affected_report_ids,
+                created_at, revoked_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            "#,
+        )
+        .bind(id)
+        .bind(report_id)
+        .bind(punishment.action.as_str())
+        .bind(punishment.scope.as_str())
+        .bind(punishment.active)
+        .bind(punishment.ban_days.map(|d| d as i32))
+        .bind(punishment.banned_until)
+        .bind(punishment.rule_removed)
+        .bind(&punishment.target_user_id)
+        .bind(&punishment.target_rule_id)
+        .bind(affected)
+        .bind(punishment.created_at)
+        .bind(punishment.revoked_at)
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        Ok(())
+    }
+
+    /// 查某条举报当前生效（active）的惩罚（撤销 / 读取补齐用）。
+    pub async fn get_active_punishment_by_report(
+        &self,
+        report_id: &Uuid,
+    ) -> Result<Option<Punishment>, AppError> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                id::text AS id,
+                report_id::text AS report_id,
+                action, scope, active, ban_days, banned_until, rule_removed,
+                target_user_id, target_rule_id, affected_report_ids,
+                created_at, revoked_at
+            FROM punishments
+            WHERE report_id = $1 AND active = true
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(report_id)
+        .fetch_optional(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        row.map(row_to_punishment).transpose()
+    }
+
+    /// 撤销一条惩罚：active=false + revoked_at。
+    pub async fn revoke_punishment(
+        &self,
+        punishment_id: &str,
+        revoked_at: i64,
+    ) -> Result<(), AppError> {
+        let id = Uuid::parse_str(punishment_id)
+            .map_err(|e| AppError::InvalidInput(format!("惩罚 ID 必须是 UUID：{e}")))?;
+        sqlx::query(
+            r#"
+            UPDATE punishments
+            SET active = false, revoked_at = $2
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(revoked_at)
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        Ok(())
+    }
+
+    /// 把一批举报标记为被某条惩罚合并：status=resolved + merged_by_punishment_id。
+    pub async fn mark_reports_merged(
+        &self,
+        punishment_id: &str,
+        report_ids: &[String],
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        for rid in report_ids {
+            let uuid = match Uuid::parse_str(rid) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+            sqlx::query(
+                r#"
+                UPDATE reports
+                SET status = 'resolved',
+                    merged_by_punishment_id = $2,
+                    updated_at = to_timestamp($3::double precision / 1000.0)
+                WHERE id = $1
+                "#,
+            )
+            .bind(uuid)
+            .bind(punishment_id)
+            .bind(updated_at)
+            .execute(&self.pool)
+            .await
+            .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+        }
+        Ok(())
+    }
+
+    /// 撤销惩罚时把被合并的举报退回 pending + 清 merged_by_punishment_id。
+    pub async fn restore_merged_reports(
+        &self,
+        punishment_id: &str,
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        sqlx::query(
+            r#"
+            UPDATE reports
+            SET status = 'pending',
+                merged_by_punishment_id = NULL,
+                updated_at = to_timestamp($2::double precision / 1000.0)
+            WHERE merged_by_punishment_id = $1
+            "#,
+        )
+        .bind(punishment_id)
+        .bind(updated_at)
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        Ok(())
+    }
+
+    /// 拉取若干 pending 举报用于合并判定（排除源举报，按 created_at DESC）。
+    pub async fn list_pending_for_merge(&self, exclude_id: &Uuid) -> Result<Vec<Report>, AppError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id::text AS id,
+                reporter_id::text AS reporter_id,
+                reporter_name,
+                reporter_avatar,
+                target_type,
+                target_id,
+                reason,
+                details,
+                status,
+                context,
+                action_log,
+                merged_by_punishment_id,
+                (EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_at,
+                (EXTRACT(EPOCH FROM updated_at) * 1000)::bigint AS updated_at
+            FROM reports
+            WHERE status = 'pending' AND id <> $1
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(exclude_id)
+        .fetch_all(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        rows.into_iter().map(row_to_report).collect()
+    }
+}
+
+fn row_to_punishment(row: PgRow) -> Result<Punishment, AppError> {
+    let action = ReportAction::from_db_str(row.get::<String, _>("action").as_str())
+        .unwrap_or(ReportAction::BanUser);
+    let scope = PunishmentScope::from_db_str(row.get::<String, _>("scope").as_str())
+        .unwrap_or(PunishmentScope::User);
+    let affected_raw: serde_json::Value = row.get("affected_report_ids");
+    let affected_report_ids: Vec<String> = serde_json::from_value(affected_raw).unwrap_or_default();
+    Ok(Punishment {
+        id: row.get("id"),
+        action,
+        scope,
+        active: row.get("active"),
+        ban_days: row.get::<Option<i32>, _>("ban_days").map(|d| d as i64),
+        banned_until: row.get("banned_until"),
+        rule_removed: row.get("rule_removed"),
+        affected_report_ids,
+        created_at: row.get("created_at"),
+        revoked_at: row.get("revoked_at"),
+        report_id: row.get("report_id"),
+        target_user_id: row.get("target_user_id"),
+        target_rule_id: row.get("target_rule_id"),
+    })
 }
 
 fn row_to_report(row: PgRow) -> Result<Report, AppError> {
@@ -309,27 +689,97 @@ fn row_to_report(row: PgRow) -> Result<Report, AppError> {
     let action_log_raw: serde_json::Value = row.get("action_log");
     let action_log: Vec<ReportActionLog> =
         serde_json::from_value(action_log_raw).unwrap_or_default();
+    let reporter_id: String = row.get("reporter_id");
+    let reporter_name: String = row.get("reporter_name");
+    let reporter_avatar: String = row.get("reporter_avatar");
+    let merged_by_punishment_id: Option<String> = row.get("merged_by_punishment_id");
+
+    // 同时填充结构化 reporter（新契约）与扁平字段（deprecated 兼容），FE 两边都读。
+    let reporter = Some(ReportUser {
+        id: reporter_id.clone(),
+        name: reporter_name.clone(),
+        avatar: reporter_avatar.clone(),
+    });
 
     Ok(Report {
         id: row.get("id"),
-        reporter_id: row.get("reporter_id"),
-        reporter_name: row.get("reporter_name"),
-        reporter_avatar: row.get("reporter_avatar"),
+        reporter,
+        reporter_id,
+        reporter_name,
+        reporter_avatar,
         target_type: ReportTargetType::from_db_str(row.get::<String, _>("target_type").as_str())
             .unwrap_or(ReportTargetType::User),
         target_id: row.get("target_id"),
+        target_user: None,
+        target_rule: None,
         reason: row.get("reason"),
         details: row.get("details"),
         status: ReportStatus::from_db_str(row.get::<String, _>("status").as_str()),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         context: normalize_context(context_raw),
+        punishment: None,
+        merged_by_punishment_id,
         action_log,
     })
 }
 
 fn now_millis() -> i64 {
     time::OffsetDateTime::now_utc().unix_timestamp_nanos() as i64 / 1_000_000
+}
+
+/// 读取时补齐结构化字段：target_user / target_rule（rule 类从 RuleStore 取 authorId/authorName）
+/// + 当前 active punishment。纯读，不改 DB。
+async fn enrich_report(
+    report: &mut Report,
+    persistence: &ReportPersistence,
+    store: &RuleStore,
+) -> Result<(), AppError> {
+    // target_user：user / player_behavior 类按派生 id 填充。
+    if report.target_user.is_none()
+        && let Some(uid) = report_target_user_id(report)
+    {
+        let label = report
+            .context
+            .as_ref()
+            .and_then(|ctx| ctx.get("targetLabel"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        report.target_user = Some(ReportTargetUser {
+            id: uid,
+            name: label,
+            avatar: None,
+        });
+    }
+    // target_rule：rule / review 类，从 RuleStore 补 name / authorId / authorName。
+    if report.target_rule.is_none()
+        && let Some(rid) = report_target_rule_id(report)
+    {
+        let (rule_name, author_id) = {
+            let guard = store.read().await;
+            match guard.published.get(&rid) {
+                Some(rule) => (Some(rule.name.clone()), Some(rule.owner_id.clone())),
+                None => (None, None),
+            }
+        };
+        let label = report
+            .context
+            .as_ref()
+            .and_then(|ctx| ctx.get("targetLabel"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        report.target_rule = Some(ReportTargetRule {
+            id: rid,
+            name: rule_name.or(label),
+            author_id,
+            author_name: None,
+        });
+    }
+    // 当前生效惩罚。
+    if let Ok(uuid) = Uuid::parse_str(&report.id) {
+        report.punishment = persistence.get_active_punishment_by_report(&uuid).await?;
+    }
+    Ok(())
 }
 
 /// POST /api/reports —— 任意登录用户提交举报。
@@ -358,19 +808,29 @@ pub async fn submit_report(
     };
 
     let now = now_millis();
+    let reporter = Some(ReportUser {
+        id: user_id.to_string(),
+        name: reporter_name.clone(),
+        avatar: reporter_avatar.clone(),
+    });
     let report = Report {
         id: Uuid::new_v4().to_string(),
+        reporter,
         reporter_id: user_id.to_string(),
         reporter_name,
         reporter_avatar,
         target_type: payload.target_type,
         target_id: payload.target_id,
+        target_user: None,
+        target_rule: None,
         reason: payload.reason,
         details: payload.details,
         status: ReportStatus::Pending,
         created_at: now,
         updated_at: now,
         context: payload.context.and_then(normalize_context),
+        punishment: None,
+        merged_by_punishment_id: None,
         action_log: Vec::new(),
     };
 
@@ -378,11 +838,12 @@ pub async fn submit_report(
     Ok(Json(ApiResponse::success(report)))
 }
 
-/// GET /api/reports —— 仅管理员，支持 status / targetType / keyword 过滤，created_at DESC。
+/// GET /api/reports —— 仅管理员，支持 status / targetType / keyword / targetUser / targetRule 过滤。
 pub async fn list_reports(
     TokenClaims { user_id, .. }: TokenClaims,
     State(persistence): State<ReportPersistence>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(store): State<RuleStore>,
     Query(query): Query<ReportListQuery>,
 ) -> Result<Json<ApiResponse<Vec<Report>>>, AppError> {
     ensure_admin(&user_id, &user_repo).await?;
@@ -401,6 +862,11 @@ pub async fn list_reports(
 
     let mut reports = persistence.list(status, target_type).await?;
 
+    // 补齐结构化字段（含 target_user / target_rule），过滤前先做，保证过滤口径与 FE 一致。
+    for report in reports.iter_mut() {
+        enrich_report(report, &persistence, &store).await?;
+    }
+
     if let Some(keyword) = query
         .keyword
         .as_deref()
@@ -408,6 +874,22 @@ pub async fn list_reports(
         .filter(|k| !k.is_empty())
     {
         reports.retain(|report| report_matches_keyword(report, keyword));
+    }
+    if let Some(tu) = query
+        .target_user
+        .as_deref()
+        .map(str::trim)
+        .filter(|k| !k.is_empty())
+    {
+        reports.retain(|report| report_matches_target_user(report, tu));
+    }
+    if let Some(tr) = query
+        .target_rule
+        .as_deref()
+        .map(str::trim)
+        .filter(|k| !k.is_empty())
+    {
+        reports.retain(|report| report_matches_target_rule(report, tr));
     }
 
     Ok(Json(ApiResponse::success(reports)))
@@ -430,22 +912,23 @@ pub async fn get_report(
     TokenClaims { user_id, .. }: TokenClaims,
     State(persistence): State<ReportPersistence>,
     State(user_repo): State<Arc<UserRepository>>,
+    State(store): State<RuleStore>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Report>>, AppError> {
     ensure_admin(&user_id, &user_repo).await?;
     let uuid = Uuid::parse_str(&id).map_err(|_| AppError::NotFound)?;
-    let report = persistence.get(&uuid).await?.ok_or(AppError::NotFound)?;
+    let mut report = persistence.get(&uuid).await?.ok_or(AppError::NotFound)?;
+    enrich_report(&mut report, &persistence, &store).await?;
     Ok(Json(ApiResponse::success(report)))
 }
 
-/// POST /api/reports/{id}/action —— 仅管理员处理举报。
-/// dismiss → rejected；ban_user / ban_rule → resolved。除了记状态 + 追加 action_log，
-/// 还按 target_type + action 执行联动封禁：
-/// - ban_user：封禁被举报用户（拒绝封禁 admin）；
-/// - ban_rule：软下架被举报规则（DB + 内存标记 banned）；
-/// - dismiss：无联动。
+/// POST /api/reports/{id}/action —— 仅管理员处理举报，完整惩罚模型：
+/// - dismiss → rejected，无联动；
+/// - ban_user / ban_rule / ban_both → resolved，按 scope 封用户（写 banned_until）/ 下架规则，
+///   建 punishment 记录，并自动合并同目标的其它 pending 举报；
+/// - revoke → 逆转该举报当前 active 惩罚（解封 / 恢复规则），退回被合并举报，源举报回 pending。
 ///
-/// 联动失败（如目标是 admin）会让整个请求失败，report 不被标 resolved。
+/// 校验口径逐一对齐 FE validateLocalAction。联动失败（如目标是 admin）在改库前返回，避免状态不一致。
 pub async fn action_report(
     TokenClaims { user_id, .. }: TokenClaims,
     State(persistence): State<ReportPersistence>,
@@ -458,51 +941,215 @@ pub async fn action_report(
     ensure_admin(&user_id, &user_repo).await?;
     let uuid = Uuid::parse_str(&id).map_err(|_| AppError::NotFound)?;
     let mut report = persistence.get(&uuid).await?.ok_or(AppError::NotFound)?;
+    // 补齐 target_rule.author_id / active punishment，校验和联动都依赖它。
+    enrich_report(&mut report, &persistence, &store).await?;
 
-    // 先执行联动副作用：任何失败（如封禁 admin）都在更新 report 状态前返回，避免状态与现实不一致。
-    match payload.action {
-        ReportAction::BanUser => {
-            let target_uuid = Uuid::parse_str(report.target_id.trim()).map_err(|_| {
-                AppError::InvalidInput("封禁用户失败：举报对象 ID 不是合法用户 ID".to_string())
-            })?;
-            let target = user_repo
-                .find_by_id(&UserId(target_uuid))
-                .await?
-                .ok_or(AppError::NotFound)?;
-            can_ban_user(&target.role)?;
-            user_repo
-                .set_user_banned(&UserId(target_uuid), true)
-                .await?;
-        }
-        ReportAction::BanRule => {
-            let rule_id = report.target_id.clone();
-            // DB：软下架（builtin 规则不在 DB，UPDATE 影响 0 行无害）。
-            rule_persistence.set_rule_banned(&rule_id, true).await?;
-            // 内存：标记 banned，不 remove，保证 restore 时能找回。
-            if let Some(rule) = store.write().await.published.get_mut(&rule_id) {
-                rule.banned = true;
-            }
-        }
-        ReportAction::Dismiss => {}
-    }
+    let params = payload.params.clone().unwrap_or_default();
+    let ban_days = params.ban_days;
+    // has_rule_author：targetRule.authorId 或 params.ruleAuthorId 任一存在。
+    let rule_author_from_store = report
+        .target_rule
+        .as_ref()
+        .and_then(|tr| tr.author_id.clone());
+    let has_rule_author = rule_author_from_store.is_some() || params.rule_author_id.is_some();
+
+    // 校验（对齐 FE validateLocalAction）。
+    validate_action(
+        payload.action,
+        report.status,
+        report.punishment.as_ref().is_some_and(|p| p.active),
+        ban_days,
+        report.target_type,
+        has_rule_author,
+    )
+    .map_err(AppError::InvalidInput)?;
 
     let now = now_millis();
+
+    match payload.action {
+        ReportAction::Dismiss => {
+            apply_status_and_log(&persistence, &uuid, &mut report, &payload, user_id.0, now)
+                .await?;
+        }
+        ReportAction::Revoke => {
+            // 取 active punishment（校验已保证存在）。
+            let punishment = report.punishment.clone().ok_or_else(|| {
+                AppError::InvalidInput("当前举报没有可撤销的有效惩罚".to_string())
+            })?;
+            // 逆转封禁 / 下架（按 scope）。
+            if matches!(
+                punishment.scope,
+                PunishmentScope::User | PunishmentScope::Both
+            ) && let Some(uid) = &punishment.target_user_id
+                && let Ok(u) = Uuid::parse_str(uid)
+            {
+                user_repo.set_user_banned_until(&UserId(u), None).await?;
+            }
+            if matches!(
+                punishment.scope,
+                PunishmentScope::Rule | PunishmentScope::Both
+            ) && let Some(rid) = &punishment.target_rule_id
+            {
+                rule_persistence.set_rule_banned(rid, false).await?;
+                if let Some(rule) = store.write().await.published.get_mut(rid) {
+                    rule.banned = false;
+                }
+            }
+            // 惩罚置失效。
+            persistence.revoke_punishment(&punishment.id, now).await?;
+            // 被合并的举报退回 pending + 清 merged_by_punishment_id。
+            persistence
+                .restore_merged_reports(&punishment.id, now)
+                .await?;
+            // 源举报退回 pending（revoke → pending）。
+            report.punishment = None;
+            apply_status_and_log(&persistence, &uuid, &mut report, &payload, user_id.0, now)
+                .await?;
+        }
+        ReportAction::BanUser | ReportAction::BanRule | ReportAction::BanBoth => {
+            let scope = action_scope(payload.action)
+                .ok_or_else(|| AppError::InvalidInput("不支持的处罚动作".to_string()))?;
+
+            // 解析被封 user：FE 传 targetUserId / ruleAuthorId 优先，否则 user 类用 target_id，
+            // rule/review 类用 RuleStore 查到的 owner_id。
+            let target_user_id: Option<String> = match scope {
+                PunishmentScope::Rule => None,
+                _ => params
+                    .target_user_id
+                    .clone()
+                    .or_else(|| params.rule_author_id.clone())
+                    .or_else(|| match report.target_type {
+                        ReportTargetType::User | ReportTargetType::PlayerBehavior => {
+                            Some(report.target_id.clone())
+                        }
+                        _ => rule_author_from_store.clone(),
+                    }),
+            };
+
+            // 解析被下架 rule：params.targetRuleId 优先，否则派生 rule id（含 context.ruleId / target_id）。
+            let target_rule_id: Option<String> = match scope {
+                PunishmentScope::User => None,
+                _ => params
+                    .target_rule_id
+                    .clone()
+                    .or_else(|| report_target_rule_id(&report)),
+            };
+
+            let mut banned_until: Option<i64> = None;
+            // 执行封用户（写 banned_until）。
+            if matches!(scope, PunishmentScope::User | PunishmentScope::Both) {
+                let uid = target_user_id
+                    .clone()
+                    .ok_or_else(|| AppError::InvalidInput("缺少被封用户 ID".to_string()))?;
+                let target_uuid = Uuid::parse_str(uid.trim()).map_err(|_| {
+                    AppError::InvalidInput("封禁用户失败：被封对象 ID 不是合法用户 ID".to_string())
+                })?;
+                let target = user_repo
+                    .find_by_id(&UserId(target_uuid))
+                    .await?
+                    .ok_or(AppError::NotFound)?;
+                can_ban_user(&target.role)?;
+                let days = ban_days.unwrap_or(0);
+                let until = now + days * 86_400_000;
+                user_repo
+                    .set_user_banned_until(&UserId(target_uuid), Some(until))
+                    .await?;
+                banned_until = Some(until);
+            }
+            // 执行下架规则。
+            let rule_removed = matches!(scope, PunishmentScope::Rule | PunishmentScope::Both);
+            if rule_removed {
+                let rid = target_rule_id
+                    .clone()
+                    .ok_or_else(|| AppError::InvalidInput("缺少被下架规则 ID".to_string()))?;
+                rule_persistence.set_rule_banned(&rid, true).await?;
+                if let Some(rule) = store.write().await.published.get_mut(&rid) {
+                    rule.banned = true;
+                }
+            }
+
+            // 建惩罚记录。
+            let punishment_id = Uuid::new_v4().to_string();
+            // 合并：扫描同目标 pending 举报。
+            let candidates = persistence.list_pending_for_merge(&uuid).await?;
+            let mut affected_report_ids: Vec<String> = Vec::new();
+            for cand in &candidates {
+                let cand_user = report_target_user_id(cand);
+                let cand_rule = report_target_rule_id(cand);
+                if same_punished_target(
+                    scope,
+                    target_user_id.as_deref(),
+                    target_rule_id.as_deref(),
+                    cand_user.as_deref(),
+                    cand_rule.as_deref(),
+                ) {
+                    affected_report_ids.push(cand.id.clone());
+                }
+            }
+
+            let punishment = Punishment {
+                id: punishment_id.clone(),
+                action: payload.action,
+                scope,
+                active: true,
+                ban_days,
+                banned_until,
+                rule_removed,
+                affected_report_ids: affected_report_ids.clone(),
+                created_at: now,
+                revoked_at: None,
+                report_id: report.id.clone(),
+                target_user_id: target_user_id.clone(),
+                target_rule_id: target_rule_id.clone(),
+            };
+            persistence.insert_punishment(&punishment).await?;
+            if !affected_report_ids.is_empty() {
+                persistence
+                    .mark_reports_merged(&punishment_id, &affected_report_ids, now)
+                    .await?;
+            }
+            report.punishment = Some(punishment);
+            apply_status_and_log(&persistence, &uuid, &mut report, &payload, user_id.0, now)
+                .await?;
+        }
+    }
+
+    Ok(Json(ApiResponse::success(report)))
+}
+
+/// 追加 action_log + 落地 status / updated_at（含 merged_by_punishment_id），并回写 DB。
+async fn apply_status_and_log(
+    persistence: &ReportPersistence,
+    uuid: &Uuid,
+    report: &mut Report,
+    payload: &ReportActionPayload,
+    operator_id: Uuid,
+    now: i64,
+) -> Result<(), AppError> {
     let status = payload.action.resulting_status();
     report.action_log.push(ReportActionLog {
         id: format!("action-{now}"),
         action: payload.action,
-        operator_id: user_id.to_string(),
-        note: payload.note.unwrap_or_default(),
+        operator_id: operator_id.to_string(),
+        note: payload.note.clone().unwrap_or_default(),
         created_at: now,
+        params: payload
+            .params
+            .as_ref()
+            .and_then(|p| serde_json::to_value(p).ok()),
     });
     report.status = status;
     report.updated_at = now;
-
+    // revoke 把源举报退回 pending 并清合并标记；其它动作保持当前 merged_by_punishment_id。
+    let merged = if payload.action == ReportAction::Revoke {
+        report.merged_by_punishment_id = None;
+        None
+    } else {
+        report.merged_by_punishment_id.as_deref()
+    };
     persistence
-        .update_action(&uuid, status, &report.action_log, now)
-        .await?;
-
-    Ok(Json(ApiResponse::success(report)))
+        .update_action(uuid, status, &report.action_log, merged, now)
+        .await
 }
 
 #[cfg(test)]
@@ -512,17 +1159,22 @@ mod tests {
     fn sample_report() -> Report {
         Report {
             id: Uuid::new_v4().to_string(),
+            reporter: None,
             reporter_id: Uuid::new_v4().to_string(),
             reporter_name: "举报人甲".to_string(),
             reporter_avatar: "/static/a.png".to_string(),
             target_type: ReportTargetType::PlayerBehavior,
             target_id: "room-ABC".to_string(),
+            target_user: None,
+            target_rule: None,
             reason: "言语辱骂".to_string(),
             details: "在对局中持续辱骂其他玩家".to_string(),
             status: ReportStatus::Pending,
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
             context: Some(serde_json::json!({"targetLabel": "房间 ABC", "roomCode": "ABC"})),
+            punishment: None,
+            merged_by_punishment_id: None,
             action_log: vec![],
         }
     }
@@ -687,6 +1339,7 @@ mod tests {
             operator_id: "admin-uuid".to_string(),
             note: "理由不充分".to_string(),
             created_at: now,
+            params: None,
         });
         report.status = status;
         report.updated_at = now;
@@ -703,6 +1356,7 @@ mod tests {
             operator_id: "admin-uuid".to_string(),
             note: String::new(),
             created_at: now + 1,
+            params: None,
         });
         assert_eq!(report.action_log.len(), 2);
     }
@@ -748,6 +1402,7 @@ mod tests {
             operator_id: "op-1".to_string(),
             note: "下架".to_string(),
             created_at: 123,
+            params: None,
         };
         let json = serde_json::to_value(&log).unwrap();
         assert_eq!(
@@ -772,5 +1427,114 @@ mod tests {
     fn can_ban_user_allows_normal_user_target() {
         assert!(can_ban_user("user").is_ok());
         assert!(can_ban_user("").is_ok());
+    }
+
+    #[test]
+    fn reporter_struct_and_flat_fields_both_serialize() {
+        // FE 同时读 reporter 结构与扁平 reporterId/Name/Avatar，两套都必须出网。
+        let mut report = sample_report();
+        report.reporter = Some(ReportUser {
+            id: report.reporter_id.clone(),
+            name: report.reporter_name.clone(),
+            avatar: report.reporter_avatar.clone(),
+        });
+        let json = serde_json::to_value(&report).unwrap();
+        assert!(json.get("reporter").and_then(|v| v.get("id")).is_some());
+        assert!(json.get("reporterId").and_then(|v| v.as_str()).is_some());
+        assert!(json.get("reporterName").and_then(|v| v.as_str()).is_some());
+        assert!(
+            json.get("reporterAvatar")
+                .and_then(|v| v.as_str())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn target_user_id_derives_for_user_and_player_behavior() {
+        let mut report = sample_report();
+        // player_behavior 类用 target_id。
+        assert_eq!(report_target_user_id(&report).as_deref(), Some("room-ABC"));
+        // 结构化 target_user 优先。
+        report.target_user = Some(ReportTargetUser {
+            id: "user-99".to_string(),
+            name: None,
+            avatar: None,
+        });
+        assert_eq!(report_target_user_id(&report).as_deref(), Some("user-99"));
+        // rule 类无 target_user 时无派生 user id。
+        let mut rule_report = sample_report();
+        rule_report.target_type = ReportTargetType::Rule;
+        rule_report.context = None;
+        assert_eq!(report_target_user_id(&rule_report), None);
+    }
+
+    #[test]
+    fn target_rule_id_derives_from_context_and_target() {
+        let mut report = sample_report();
+        report.target_type = ReportTargetType::Rule;
+        report.context = Some(serde_json::json!({"ruleId": "rule_ctx"}));
+        // context.ruleId 优先于 target_id。
+        assert_eq!(report_target_rule_id(&report).as_deref(), Some("rule_ctx"));
+        // 无 context 时 rule 类用 target_id。
+        report.context = None;
+        report.target_id = "rule_tid".to_string();
+        assert_eq!(report_target_rule_id(&report).as_deref(), Some("rule_tid"));
+        // 结构化 target_rule 优先。
+        report.target_rule = Some(ReportTargetRule {
+            id: "rule_struct".to_string(),
+            name: None,
+            author_id: None,
+            author_name: None,
+        });
+        assert_eq!(
+            report_target_rule_id(&report).as_deref(),
+            Some("rule_struct")
+        );
+    }
+
+    #[test]
+    fn target_user_and_rule_filters_match_structured_fields() {
+        let mut report = sample_report();
+        report.target_user = Some(ReportTargetUser {
+            id: "user-7".to_string(),
+            name: Some("Bob".to_string()),
+            avatar: None,
+        });
+        assert!(report_matches_target_user(&report, "user-7"));
+        assert!(report_matches_target_user(&report, "bob"));
+        assert!(!report_matches_target_user(&report, "zzz"));
+        // 空过滤视为全命中。
+        assert!(report_matches_target_user(&report, ""));
+
+        let mut rule_report = sample_report();
+        rule_report.target_type = ReportTargetType::Rule;
+        rule_report.target_rule = Some(ReportTargetRule {
+            id: "rule_x".to_string(),
+            name: Some("斗地主".to_string()),
+            author_id: None,
+            author_name: None,
+        });
+        assert!(report_matches_target_rule(&rule_report, "rule_x"));
+        assert!(report_matches_target_rule(&rule_report, "斗地主"));
+        assert!(!report_matches_target_rule(&rule_report, "麻将"));
+    }
+
+    #[test]
+    fn action_params_roundtrip_camel_case() {
+        let payload: ReportActionPayload = serde_json::from_value(serde_json::json!({
+            "action": "ban_both",
+            "note": "封号下架",
+            "params": {
+                "banDays": 7,
+                "ruleAuthorId": "author-1",
+                "targetRuleId": "rule_1"
+            }
+        }))
+        .unwrap();
+        assert_eq!(payload.action, ReportAction::BanBoth);
+        let params = payload.params.unwrap();
+        assert_eq!(params.ban_days, Some(7));
+        assert_eq!(params.rule_author_id.as_deref(), Some("author-1"));
+        assert_eq!(params.target_rule_id.as_deref(), Some("rule_1"));
     }
 }

--- a/src/interface/rule.rs
+++ b/src/interface/rule.rs
@@ -533,7 +533,7 @@ pub async fn ensure_not_banned(
         .find_by_id(user_id)
         .await?
         .ok_or(AppError::Unauthorized("用户不存在".to_string()))?;
-    if user.banned {
+    if crate::domain::report::is_banned(user.banned_until, now_millis()) {
         return Err(AppError::Forbidden(
             "账号已被封禁，无法执行该操作".to_string(),
         ));
@@ -559,7 +559,7 @@ pub async fn unban_user(
     let target_uuid = Uuid::parse_str(target_id.trim())
         .map_err(|_| AppError::InvalidInput("用户 ID 不是合法 UUID".to_string()))?;
     user_repo
-        .set_user_banned(&UserId(target_uuid), false)
+        .set_user_banned_until(&UserId(target_uuid), None)
         .await?;
     Ok(Json(ApiResponse::success(())))
 }
@@ -1049,6 +1049,17 @@ impl RulePersistence {
             r#"
             ALTER TABLE users
                 ADD COLUMN IF NOT EXISTS banned BOOLEAN NOT NULL DEFAULT false
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .inspect_err(|e| tracing::warn!("Database error {e}"))?;
+
+        // 封禁时长：users 表加 banned_until（毫秒时间戳），NULL = 未封禁。幂等升级。
+        sqlx::query(
+            r#"
+            ALTER TABLE users
+                ADD COLUMN IF NOT EXISTS banned_until BIGINT
             "#,
         )
         .execute(&self.pool)

--- a/src/interface/user.rs
+++ b/src/interface/user.rs
@@ -43,6 +43,13 @@ pub struct UserDto {
     pub role: String,
     #[serde(default)]
     pub banned: bool,
+    /// 封禁到期时间戳（毫秒）。前端可据此显示剩余封禁时间；None 不输出。
+    #[serde(
+        rename = "bannedUntil",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub banned_until: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }
@@ -56,6 +63,7 @@ impl UserDto {
             avatar: user.avatar,
             role: user.role,
             banned: user.banned,
+            banned_until: user.banned_until,
             token: None,
         }
     }
@@ -363,6 +371,7 @@ pub async fn register(
         // 新注册一律是普通用户；首任管理员靠 init.sql / ensure_schema 的 UPDATE Tanhhhhtjy 完成。
         role: "user".to_string(),
         banned: false,
+        banned_until: None,
     };
     user_repo.register(user).await?;
 
@@ -408,8 +417,9 @@ pub async fn login(
             return Err(AppError::InvalidInput("账号或密码错误".to_string()));
         }
 
-        // 封禁拦截：密码正确但账号已封禁，拒绝登录（解封后可重新登录）。
-        if user.banned {
+        // 封禁拦截：密码正确但账号封禁未到期，拒绝登录（到期 / 解封后可重新登录）。
+        let now_ms = time::OffsetDateTime::now_utc().unix_timestamp_nanos() as i64 / 1_000_000;
+        if crate::domain::report::is_banned(user.banned_until, now_ms) {
             return Err(AppError::Forbidden("账号已被封禁".to_string()));
         }
 
@@ -801,6 +811,7 @@ mod tests {
             avatar: "/avatar.png".to_string(),
             role: "admin".to_string(),
             banned: false,
+            banned_until: None,
         };
 
         let dto = UserDto::from_user(user);
@@ -820,6 +831,7 @@ mod tests {
             avatar: "/avatar.png".to_string(),
             role: "admin".to_string(),
             banned: false,
+            banned_until: None,
         };
 
         let dto = UserDto::from_user_with_token(user, "jwt-token".to_string());

--- a/tests/infrastructure_coverage_tests.rs
+++ b/tests/infrastructure_coverage_tests.rs
@@ -157,6 +157,7 @@ mod infrastructure {
                     avatar: String::new(),
                     role: "user".to_string(),
                     banned: false,
+                    banned_until: None,
                 }
             }
 

--- a/tests/market_interface_coverage_tests.rs
+++ b/tests/market_interface_coverage_tests.rs
@@ -59,6 +59,7 @@ mod infrastructure {
                     avatar: String::new(),
                     role: self.role.clone(),
                     banned: self.banned,
+                    banned_until: None,
                 }))
             }
         }

--- a/tests/report_interface_coverage_tests.rs
+++ b/tests/report_interface_coverage_tests.rs
@@ -40,6 +40,7 @@ mod infrastructure {
             avatar: String,
             role: String,
             banned: bool,
+            banned_until: Option<i64>,
         }
 
         impl StoredUser {
@@ -52,6 +53,7 @@ mod infrastructure {
                     avatar: user.avatar,
                     role: user.role,
                     banned: user.banned,
+                    banned_until: user.banned_until,
                 }
             }
 
@@ -64,6 +66,7 @@ mod infrastructure {
                     avatar: self.avatar.clone(),
                     role: self.role.clone(),
                     banned: self.banned,
+                    banned_until: self.banned_until,
                 }
             }
         }
@@ -101,6 +104,18 @@ mod infrastructure {
             ) -> Result<(), AppError> {
                 if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
                     user.banned = banned;
+                }
+                Ok(())
+            }
+
+            pub async fn set_user_banned_until(
+                &self,
+                user_id: &UserId,
+                until: Option<i64>,
+            ) -> Result<(), AppError> {
+                if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
+                    user.banned_until = until;
+                    user.banned = until.is_some();
                 }
                 Ok(())
             }
@@ -185,10 +200,12 @@ mod interface {
             Ok(())
         }
 
-        /// 最小化的已发布规则：报表联动只读 / 写 `banned` 字段。
+        /// 最小化的已发布规则：报表联动只读 / 写 `banned`，补齐 enrich 需要的 name / owner_id。
         #[derive(Debug, Default, Clone)]
         pub struct PublishedRule {
             pub id: String,
+            pub name: String,
+            pub owner_id: String,
             pub banned: bool,
         }
 
@@ -263,6 +280,7 @@ fn user(id: Uuid, name: &str, role: &str) -> User {
         avatar: format!("/static/avatars/{name}.png"),
         role: role.to_string(),
         banned: false,
+        banned_until: None,
     }
 }
 
@@ -277,11 +295,14 @@ fn persistence() -> ReportPersistence {
 fn sample_report() -> Report {
     Report {
         id: Uuid::new_v4().to_string(),
+        reporter: None,
         reporter_id: "reporter-1".to_string(),
         reporter_name: "Alice".to_string(),
         reporter_avatar: String::new(),
         target_type: ReportTargetType::PlayerBehavior,
         target_id: "room-42".to_string(),
+        target_user: None,
+        target_rule: None,
         reason: "恶意拖延".to_string(),
         details: "最后一轮持续不操作".to_string(),
         status: ReportStatus::Pending,
@@ -292,6 +313,8 @@ fn sample_report() -> Report {
             "roomCode": "42",
             "sourcePath": "/battle/room-42"
         })),
+        punishment: None,
+        merged_by_punishment_id: None,
         action_log: vec![],
     }
 }
@@ -335,11 +358,7 @@ fn report_action_payload_preserves_optional_params_for_frontend_contract() {
     assert_eq!(payload.action, ReportAction::BanRule);
     assert_eq!(payload.note.as_deref(), Some("封禁相关规则"));
     assert_eq!(
-        payload
-            .params
-            .as_ref()
-            .and_then(|v| v.get("targetId"))
-            .and_then(|v| v.as_str()),
+        payload.params.as_ref().and_then(|p| p.target_id.as_deref()),
         Some("rule-1")
     );
 }
@@ -411,6 +430,9 @@ async fn admin_report_detail_invalid_id_returns_not_found_without_database_looku
         State(Arc::new(UserRepository::with_users(vec![user(
             admin_id, "admin", "admin",
         )]))),
+        State(Arc::new(tokio::sync::RwLock::new(
+            interface::rule::RuleRepository::default(),
+        ))),
         axum::extract::Path("counts".to_string()),
     )
     .await;

--- a/tests/room_game_pressure_tests.rs
+++ b/tests/room_game_pressure_tests.rs
@@ -61,6 +61,7 @@ mod infrastructure {
             avatar: String,
             role: String,
             banned: bool,
+            banned_until: Option<i64>,
         }
 
         impl StoredUser {
@@ -73,6 +74,7 @@ mod infrastructure {
                     avatar: self.avatar,
                     role: self.role,
                     banned: self.banned,
+                    banned_until: self.banned_until,
                 }
             }
         }
@@ -105,6 +107,7 @@ mod infrastructure {
                                         avatar: user.avatar,
                                         role: user.role,
                                         banned: user.banned,
+                                        banned_until: None,
                                     },
                                 )
                             })
@@ -384,6 +387,7 @@ fn user(id: Uuid, name: &str) -> User {
         avatar: String::new(),
         role: "user".to_string(),
         banned: false,
+        banned_until: None,
     }
 }
 

--- a/tests/room_interface_coverage_tests.rs
+++ b/tests/room_interface_coverage_tests.rs
@@ -61,6 +61,7 @@ mod infrastructure {
                     avatar: self.avatar,
                     role: self.role,
                     banned: false,
+                    banned_until: None,
                 }
             }
         }
@@ -266,6 +267,7 @@ fn user(id: Uuid, name: &str) -> User {
         avatar: format!("/{name}.png"),
         role: "user".to_string(),
         banned: false,
+        banned_until: None,
     }
 }
 

--- a/tests/rule_interface_coverage_tests.rs
+++ b/tests/rule_interface_coverage_tests.rs
@@ -17,6 +17,10 @@ mod domain {
         pub use wildcard_backend::domain::user::*;
     }
 
+    pub mod report {
+        pub use wildcard_backend::domain::report::*;
+    }
+
     pub mod rule_engine {
         pub use wildcard_backend::domain::rule_engine::*;
     }
@@ -43,6 +47,7 @@ mod infrastructure {
             avatar: String,
             role: String,
             banned: bool,
+            banned_until: Option<i64>,
         }
 
         impl StoredUser {
@@ -55,6 +60,7 @@ mod infrastructure {
                     avatar: self.avatar,
                     role: self.role,
                     banned: self.banned,
+                    banned_until: self.banned_until,
                 }
             }
         }
@@ -81,6 +87,7 @@ mod infrastructure {
                                         avatar: user.avatar,
                                         role: user.role,
                                         banned: user.banned,
+                                        banned_until: user.banned_until,
                                     },
                                 )
                             })
@@ -106,6 +113,18 @@ mod infrastructure {
             ) -> Result<(), AppError> {
                 if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
                     user.banned = banned;
+                }
+                Ok(())
+            }
+
+            pub async fn set_user_banned_until(
+                &self,
+                user_id: &UserId,
+                until: Option<i64>,
+            ) -> Result<(), AppError> {
+                if let Some(user) = self.users.write().await.get_mut(&user_id.0) {
+                    user.banned_until = until;
+                    user.banned = until.is_some();
                 }
                 Ok(())
             }
@@ -284,6 +303,8 @@ fn repo_with_state(user_id: Uuid, role: &str, banned: bool) -> Arc<UserRepositor
         avatar: String::new(),
         role: role.to_string(),
         banned,
+        // 拦截逻辑改读 banned_until：封禁时给一个远期到期时间戳。
+        banned_until: if banned { Some(i64::MAX) } else { None },
     }]))
 }
 
@@ -487,6 +508,7 @@ async fn admin_endpoints_stop_on_auth_guard_with_fake_repository() {
         avatar: String::new(),
         role: "user".to_string(),
         banned: false,
+        banned_until: None,
     };
     let repo = Arc::new(UserRepository::with_users(vec![normal_user]));
     let store = store_with(
@@ -619,6 +641,7 @@ async fn admin_review_success_and_conflict_paths_cover_authorized_flow() {
         avatar: String::new(),
         role: "admin".to_string(),
         banned: false,
+        banned_until: None,
     };
     let owner = User {
         id: UserId(owner_id),
@@ -628,6 +651,7 @@ async fn admin_review_success_and_conflict_paths_cover_authorized_flow() {
         avatar: String::new(),
         role: "user".to_string(),
         banned: false,
+        banned_until: None,
     };
     let repo = Arc::new(UserRepository::with_users(vec![admin, owner]));
     let mut pending_old = draft(owner_id, "pending-old", RuleStatus::PendingReview, 1);
@@ -873,6 +897,7 @@ async fn admin_can_unban_user_through_handler() {
             avatar: String::new(),
             role: "admin".to_string(),
             banned: false,
+            banned_until: None,
         },
         User {
             id: UserId(target_id),
@@ -882,6 +907,7 @@ async fn admin_can_unban_user_through_handler() {
             avatar: String::new(),
             role: "user".to_string(),
             banned: true,
+            banned_until: None,
         },
     ]));
 
@@ -910,6 +936,7 @@ async fn admin_approve_reject_pending_paths_reach_persistence_error_branches() {
         avatar: String::new(),
         role: "admin".to_string(),
         banned: false,
+        banned_until: None,
     };
     let repo = Arc::new(UserRepository::with_users(vec![admin]));
 

--- a/tests/user_login_avatar_http_tests.rs
+++ b/tests/user_login_avatar_http_tests.rs
@@ -17,6 +17,9 @@ mod domain {
     pub mod user {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/domain/user.rs"));
     }
+    pub mod report {
+        pub use wildcard_backend::domain::report::*;
+    }
 }
 
 mod error {
@@ -63,6 +66,7 @@ mod infrastructure {
             avatar: String,
             role: String,
             banned: bool,
+            banned_until: Option<i64>,
         }
 
         impl StoredUser {
@@ -75,6 +79,7 @@ mod infrastructure {
                     avatar: self.avatar,
                     role: self.role,
                     banned: self.banned,
+                    banned_until: self.banned_until,
                 }
             }
         }
@@ -115,6 +120,8 @@ mod infrastructure {
                         avatar: avatar.to_string(),
                         role: role.to_string(),
                         banned,
+                        // banned bool 已迁移到 banned_until 时间戳语义：banned=true 等价于一个远期封禁。
+                        banned_until: if banned { Some(i64::MAX) } else { None },
                     },
                 );
 
@@ -142,6 +149,7 @@ mod infrastructure {
                         avatar: user.avatar,
                         role: user.role,
                         banned: user.banned,
+                        banned_until: None,
                     },
                 );
                 Ok(())


### PR DESCRIPTION
## Summary
对齐前端 PR #191 的举报审核系统升级，把后端从旧版（永久 bool 封禁、无时长/撤销/合并/筛选）升级为完整的惩罚（Punishment）模型。前端契约源：`WildCard_FrontEnd/src/api/report.ts`。

落地 7 项前端新功能：
- **封禁时长** banDays(1/3/5/7/30)：`users.banned_until` 时间戳列，登录/写接口懒判断 `now < banned_until`，过期自动解封，无需 cron
- **撤销惩罚** revoke：逆转封禁/下架（按 scope），被合并举报退回 pending，punishment.active=false
- **合并同目标**：处罚时自动 resolved 同 user/同 rule 的其它 pending 举报，记 `mergedByPunishmentId` + `affectedReportIds`
- **同时惩罚** ban_both：scope=both，封作者 + 下架规则
- **按用户/规则筛选**：`GET /api/reports?targetUser=&targetRule=`，keyword 扩展匹配
- **详情结构化信息**：返回 `reporter`/`targetUser`/`targetRule`/`punishment`（保留旧扁平别名做兼容）
- **独立 punishments 表**：封作者从内存 RuleStore 的 owner_id 派生，不只信前端传参

## 实现要点
- 纯函数 `is_banned` / `same_punished_target` / `validate_action` 逐一对齐 FE `isSamePunishedTarget` / `validateLocalAction`
- `init.sql` + 各 `ensure_schema` 双写，幂等 ALTER TABLE
- `set_user_banned` → `set_user_banned_until(Option<i64>)`，旧 banned bool 同步写

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --all-targets（0 warning）
- [x] cargo test（全部通过）
- [x] autocorrect --lint（No issues）
- [ ] 部署后线上 E2E：时长封禁/懒解封、撤销、合并、ban_both、筛选、防误封 admin